### PR TITLE
Add option to open a remote in DocumentsUI

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/EditRemoteDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/EditRemoteDialogFragment.kt
@@ -14,10 +14,11 @@ open class EditRemoteDialogFragment : DialogFragment() {
         const val RESULT_ACTION = "action"
         const val RESULT_REMOTE = "remote"
         // These must match the indexes in R.array.dialog_edit_remote_actions
-        const val ACTION_CONFIGURE = 0
-        const val ACTION_RENAME = 1
-        const val ACTION_DUPLICATE = 2
-        const val ACTION_DELETE = 3
+        const val ACTION_OPEN = 0
+        const val ACTION_CONFIGURE = 1
+        const val ACTION_RENAME = 2
+        const val ACTION_DUPLICATE = 3
+        const val ACTION_DELETE = 4
 
         fun newInstance(remote: String): EditRemoteDialogFragment =
             EditRemoteDialogFragment().apply {

--- a/app/src/main/java/com/chiller3/rsaf/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/SettingsFragment.kt
@@ -3,6 +3,7 @@ package com.chiller3.rsaf
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.provider.DocumentsContract
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.FragmentResultListener
 import androidx.fragment.app.clearFragmentResult
@@ -224,6 +225,14 @@ class SettingsFragment : PreferenceFragmentCompat(), FragmentResultListener,
                 val remote = bundle.getString(EditRemoteDialogFragment.RESULT_REMOTE)!!
 
                 when (action) {
+                    EditRemoteDialogFragment.ACTION_OPEN -> {
+                        val uri = DocumentsContract.buildRootUri(
+                            BuildConfig.DOCUMENTS_AUTHORITY, remote)
+                        val intent = Intent(Intent.ACTION_VIEW).apply {
+                            setDataAndType(uri, "vnd.android.document/root")
+                        }
+                        startActivity(intent)
+                    }
                     EditRemoteDialogFragment.ACTION_CONFIGURE -> {
                         InteractiveConfigurationDialogFragment.newInstance(remote, false)
                             .show(parentFragmentManager.beginTransaction(),

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="dialog_edit_remote_actions">
+        <item>@string/dialog_edit_remote_open_in_documentsui</item>
         <item>@string/dialog_edit_remote_action_configure</item>
         <item>@string/dialog_edit_remote_action_rename</item>
         <item>@string/dialog_edit_remote_action_duplicate</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="dialog_authorize_title">Waiting for authorization</string>
     <string name="dialog_authorize_message_loading">Waiting for rclone webserver to start.</string>
     <string name="dialog_authorize_message_url">Open the following link to authorize rclone for access to the backend. Once authorized, the token will be automatically inserted in the previous screen.</string>
+    <string name="dialog_edit_remote_open_in_documentsui">Open in DocumentsUI</string>
     <string name="dialog_edit_remote_action_configure">Configure remote</string>
     <string name="dialog_edit_remote_action_rename">Rename remote</string>
     <string name="dialog_edit_remote_action_duplicate">Duplicate remote</string>


### PR DESCRIPTION
Some Android builds (eg. Samsung OneUI) don't have a convenient way of launching DocumentsUI, so we'll add an option to do that.