### PR TITLE
isChildDocument: Return true for nested children

### DIFF
--- a/app/src/androidTest/java/com/chiller3/rsaf/RcloneProviderTest.kt
+++ b/app/src/androidTest/java/com/chiller3/rsaf/RcloneProviderTest.kt
@@ -256,8 +256,9 @@ class RcloneProviderTest {
         }
 
         assertTrue(isChild(docUriFromRoot(), docUriFromRoot("child")))
-        assertFalse(isChild(docUriFromRoot(), docUriFromRoot("nested", "child")))
+        assertTrue(isChild(docUriFromRoot(), docUriFromRoot("nested", "child")))
         assertTrue(isChild(docUriFromRoot("dir"), docUriFromRoot("dir", "child")))
+        assertTrue(isChild(docUriFromRoot("dir"), docUriFromRoot("dir", "nested", "child")))
         assertFalse(isChild(docUriFromRoot(), docUriFromRoot()))
         assertFalse(isChild(docUriFromRoot("dir"), docUriFromRoot("dir")))
     }
@@ -492,17 +493,22 @@ class RcloneProviderTest {
         testDelete { DocumentsContract.removeDocument(appContext.contentResolver, it, rootDocUri) }
 
         // Try deleting a file from the wrong parent
-        File(rootDir, "dir").apply {
+        File(rootDir, "dir1").apply {
             assertTrue(mkdir())
             File(this, "file").apply {
                 assertTrue(createNewFile())
             }
         }
-
-        val uri = docUriFromRoot("dir", "file")
+        File(rootDir, "dir2").apply {
+            assertTrue(mkdir())
+        }
 
         assertThrows(IllegalArgumentException::class.java) {
-            DocumentsContract.removeDocument(appContext.contentResolver, uri, rootDocUri)
+            DocumentsContract.removeDocument(
+                appContext.contentResolver,
+                docUriFromRoot("dir1", "file"),
+                docUriFromRoot("dir2"),
+            )
         }
     }
 

--- a/app/src/main/java/com/chiller3/rsaf/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/RcloneProvider.kt
@@ -341,9 +341,30 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
     override fun isChildDocument(parentDocumentId: String, documentId: String): Boolean {
         debugLog("isChildDocument($parentDocumentId, $documentId)")
 
-        val (splitParent, splitName) = splitPath(documentId)
+        // AOSP's FileSystemProvider [1] returns true [2] if parentDocumentId and documentId refer
+        // to the same path, but this conflicts with the documented behavior of isChildDocument(),
+        // which is supposed to test "if a document is descendant (child, grandchild, etc) from the
+        // given parent". We'll go with the documented behavior instead of matching AOSP's
+        // FileSystemProvider.
+        //
+        // [1] https://cs.android.com/android/platform/superproject/+/android-13.0.0_r49:frameworks/base/core/java/com/android/internal/content/FileSystemProvider.java;l=141
+        // [2] https://cs.android.com/android/platform/superproject/+/android-13.0.0_r49:frameworks/base/core/java/android/os/FileUtils.java;l=917
 
-        return splitName.isNotEmpty() && splitParent == parentDocumentId
+        var currentDoc = documentId
+
+        while (true) {
+            val (splitParent, splitName) = splitPath(currentDoc)
+            if (splitName.isEmpty()) {
+                // Root of the remote
+                break
+            } else if (splitParent == parentDocumentId) {
+                return true
+            }
+
+            currentDoc = splitParent
+        }
+
+        return false
     }
 
     /**


### PR DESCRIPTION
The function previously only returned true for immediate children, which did not adhere to the DocumentsProvider contract and caused some applications, like mpv, to crash.