### PR TITLE
rcbridge: Set cache dir via XDG_CACHE_HOME

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -232,6 +232,7 @@ val rcbridge = tasks.register<Exec>("rcbridge") {
         File(rcbridgeSrcDir, "go.mod"),
         File(rcbridgeSrcDir, "go.sum"),
         File(rcbridgeSrcDir, "rcbridge.go"),
+        File(File(rcbridgeSrcDir, "envhack"), "envhack.go"),
     )
     inputs.properties(
         "android.defaultConfig.minSdk" to android.defaultConfig.minSdk,
@@ -341,7 +342,7 @@ fun checkBrackets(line: String) {
 
 fun updateChangelogLinks(baseUrl: String) {
     val file = File(rootDir, "CHANGELOG.md")
-    var regexStandaloneLink = Regex("\\[([^\\]]+)\\](?![\\(\\[])")
+    val regexStandaloneLink = Regex("\\[([^\\]]+)\\](?![\\(\\[])")
     val regexAutoLink = Regex("(Issue|PR) #(\\d+)(?: @([\\w-]+))?")
     val links = hashMapOf<LinkRef, String>()
     var skipRemaining = false

--- a/rcbridge/envhack/envhack.go
+++ b/rcbridge/envhack/envhack.go
@@ -1,0 +1,37 @@
+package envhack
+
+/*
+#include <unistd.h>
+*/
+import "C"
+import (
+	"os"
+	"strings"
+	"unsafe"
+)
+
+func init() {
+	// Golang has its own internal copy of the environment variables. When using
+	// go as a shared library, the internal map never gets populated from
+	// _start()'s envp, so no environment variables are accessible. This
+	// terrible hack allows us to explicitly copy the environment variables from
+	// libc.
+
+	ptr := C.environ
+
+	for {
+		if *ptr == nil {
+			break
+		}
+
+		key_value := C.GoString(*ptr)
+		pieces := strings.SplitN(key_value, "=", 2)
+		if len(pieces) != 2 {
+			continue
+		}
+
+		os.Setenv(pieces[0], pieces[1])
+
+		ptr = (**C.char)(unsafe.Add(unsafe.Pointer(ptr), unsafe.Sizeof(ptr)))
+	}
+}

--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -13,6 +13,9 @@
 package rcbridge
 
 import (
+	// This package's init() MUST run first
+	_ "rcbridge/envhack"
+
 	"context"
 	"io"
 	ioFs "io/fs"
@@ -65,9 +68,8 @@ var (
 )
 
 // Initialize global aspects of the library.
-func RbInit(cacheDir string) {
+func RbInit() {
 	librclone.Initialize()
-	config.SetCacheDir(cacheDir)
 
 	// Don't allow interactive password prompts
 	ci := fs.GetConfig(context.Background())


### PR DESCRIPTION
Due to how golang calls each packages' `init()` functions, it's impossible to have a shared library function that runs before any of the `init()`s. Instead, we'll set the `XDG_CACHE_HOME` environment variable. This has its own problems because calling `setenv()` from the Kotlin side only affects libc's global `environ` variable, which golang does not use (it maintains its own copy of `envp`). This commit works around that by importing a new `envhack` package that explicitly copies libc's `environ` to golang via CGO.

Fixes: #11