### PR TITLE
Improve interactive configuration dialog

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/RcloneConfig.kt
+++ b/app/src/main/java/com/chiller3/rsaf/RcloneConfig.kt
@@ -223,4 +223,12 @@ object RcloneConfig {
 
     class BadPasswordException(message: String?, cause: Throwable? = null)
         : Exception(message, cause)
+
+    fun revealPassword(obscured: String): String {
+        val error = RbError()
+        val result = Rcbridge.rbPasswordReveal(obscured, error)
+            ?: throw error.toException("rbPasswordReveal")
+
+        return result.plainText
+    }
 }

--- a/app/src/main/res/layout/dialog_interactive_configuration.xml
+++ b/app/src/main/res/layout/dialog_interactive_configuration.xml
@@ -17,13 +17,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <com.google.android.material.materialswitch.MaterialSwitch
-            android:id="@+id/use_default"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/abc_dialog_title_divider_material"
-            android:visibility="gone" />
-
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/text_layout"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="dialog_action_ok">OK</string>
     <string name="dialog_action_cancel">Cancel</string>
     <string name="dialog_action_authorize">Authorize</string>
+    <string name="dialog_action_reset">Reset</string>
     <string name="dialog_remote_name_message">Enter a name for the remote.</string>
     <string name="dialog_remote_name_hint">Remote name</string>
     <string name="dialog_add_remote_title">Add remote</string>
@@ -77,8 +78,6 @@
     <!-- Interactive configuration -->
     <string name="ic_title_add_remote">Add remote: %1$s</string>
     <string name="ic_title_edit_remote">Edit remote: %1$s</string>
-    <string name="ic_use_default_value">Use default value: \"%1$s\"</string>
-    <string name="ic_use_current_value">Use current value: \"%1$s\"</string>
     <string name="ic_text_box_helper_required">Value must not be empty.</string>
     <string name="ic_text_box_helper_not_required">Value can be empty.</string>
     <string name="ic_header_examples">Example options:</string>

--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -32,6 +32,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/cache"
 	"github.com/rclone/rclone/fs/config"
+	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/rclone/rclone/fs/fspath"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fs/sync"
@@ -249,6 +250,22 @@ func RbConfigSave(errOut *RbError) bool {
 	}
 
 	return true
+}
+
+type RbPasswordRevealResult struct {
+	PlainText string
+}
+
+func RbPasswordReveal(obscured string, errOut *RbError) *RbPasswordRevealResult {
+	plainText, err := obscure.Reveal(obscured)
+	if err != nil {
+		assignError(errOut, err, syscall.EINVAL)
+		return nil
+	}
+
+	return &RbPasswordRevealResult{
+		PlainText: plainText,
+	}
 }
 
 // Create an fs instance or get it from the cache if it exists. The path can


### PR DESCRIPTION
* The existing password is unobscured before being shown to the user.
* The "Use current value"/"Use default value" options have been replaced with a reset button.
* The password input box now has a show password button.

Fixes: #8