### PR TITLE
Add option to show all dialogs at the bottom of the screen

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/AuthorizeDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/AuthorizeDialogFragment.kt
@@ -3,6 +3,7 @@ package com.chiller3.rsaf
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
+import android.view.Gravity
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
@@ -49,6 +50,10 @@ open class AuthorizeDialogFragment : DialogFragment() {
             .setCancelable(false)
             .create()
             .apply {
+                if (Preferences(requireContext()).dialogsAtBottom) {
+                    window!!.attributes.gravity = Gravity.BOTTOM
+                }
+
                 setCanceledOnTouchOutside(false)
             }
 

--- a/app/src/main/java/com/chiller3/rsaf/EditRemoteDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/EditRemoteDialogFragment.kt
@@ -3,6 +3,7 @@ package com.chiller3.rsaf
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
+import android.view.Gravity
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
@@ -43,6 +44,11 @@ open class EditRemoteDialogFragment : DialogFragment() {
                 dismiss()
             }
             .create()
+            .apply {
+                if (Preferences(requireContext()).dialogsAtBottom) {
+                    window!!.attributes.gravity = Gravity.BOTTOM
+                }
+            }
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/app/src/main/java/com/chiller3/rsaf/InteractiveConfigurationDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/InteractiveConfigurationDialogFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.system.ErrnoException
 import android.text.InputType
 import android.util.Log
+import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
@@ -138,6 +139,10 @@ class InteractiveConfigurationDialogFragment : DialogFragment() {
             .setCancelable(false)
             .create()
             .apply {
+                if (Preferences(requireContext()).dialogsAtBottom) {
+                    window!!.attributes.gravity = Gravity.BOTTOM
+                }
+
                 setCanceledOnTouchOutside(false)
 
                 // Set click handlers manually because doing it via the alert dialog builder forces

--- a/app/src/main/java/com/chiller3/rsaf/Preferences.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Preferences.kt
@@ -13,6 +13,7 @@ class Preferences(context: Context) {
 
         const val PREF_ADD_FILE_EXTENSION = "add_file_extension"
         const val PREF_ALLOW_BACKUP = "allow_backup"
+        const val PREF_DIALOGS_AT_BOTTOM = "dialogs_at_bottom"
         const val PREF_POSIX_LIKE_SEMANTICS = "posix_like_semantics"
         const val PREF_PRETEND_LOCAL = "pretend_local"
         const val PREF_VERBOSE_RCLONE_LOGS = "verbose_rclone_logs"
@@ -57,6 +58,11 @@ class Preferences(context: Context) {
     var pretendLocal: Boolean
         get() = prefs.getBoolean(PREF_PRETEND_LOCAL, false)
         set(enabled) = prefs.edit { putBoolean(PREF_PRETEND_LOCAL, enabled) }
+
+    /** Whether to show dialogs at the bottom of the screen. */
+    var dialogsAtBottom: Boolean
+        get() = prefs.getBoolean(PREF_DIALOGS_AT_BOTTOM, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_DIALOGS_AT_BOTTOM, enabled) }
 
     /** Whether to allow app data backups. */
     var allowBackup: Boolean

--- a/app/src/main/java/com/chiller3/rsaf/TextInputDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/TextInputDialogFragment.kt
@@ -4,6 +4,7 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.text.InputType
+import android.view.Gravity
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.core.widget.addTextChangedListener
@@ -67,6 +68,11 @@ open class TextInputDialogFragment : DialogFragment() {
             }
             .setNegativeButton(R.string.dialog_action_cancel, null)
             .create()
+            .apply {
+                if (Preferences(requireContext()).dialogsAtBottom) {
+                    window!!.attributes.gravity = Gravity.BOTTOM
+                }
+            }
     }
 
     override fun onStart() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="pref_header_remotes">Remotes</string>
     <string name="pref_header_configuration">Configuration</string>
     <string name="pref_header_behavior">Behavior</string>
+    <string name="pref_header_ui">UI</string>
     <string name="pref_header_advanced">Advanced</string>
     <string name="pref_header_about">About</string>
     <string name="pref_header_debug">Debug</string>
@@ -21,6 +22,8 @@
     <string name="pref_posix_like_semantics_desc_off">Use Android-style file operation behavior. When creating, renaming, copying, or moving paths, add a number to the name to avoid conflicts if the target path already exists.</string>
     <string name="pref_pretend_local_name">Pretend to be local storage</string>
     <string name="pref_pretend_local_desc">Present the rclone remotes as local storage to the Storage Access Framework. This forces compatibility with apps that only allow selecting local files.</string>
+    <string name="pref_dialogs_at_bottom_name">Show dialogs at bottom</string>
+    <string name="pref_dialogs_at_bottom_desc">Makes one-handed use easier and prevents dialog buttons from shifting.</string>
     <string name="pref_allow_backup_name">Allow Android backups</string>
     <string name="pref_allow_backup_desc">Allow app data to be backed up if Android claims that the transport is end-to-end encrypted or if it is being directly transferred to another device. RSAF cannot know if either of these conditions are actually true.</string>
     <string name="pref_version_name">Version</string>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -58,6 +58,17 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        app:title="@string/pref_header_ui"
+        app:iconSpaceReserved="false">
+
+        <SwitchPreferenceCompat
+            app:key="dialogs_at_bottom"
+            app:title="@string/pref_dialogs_at_bottom_name"
+            app:summary="@string/pref_dialogs_at_bottom_desc"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         app:title="@string/pref_header_advanced"
         app:iconSpaceReserved="false">
 


### PR DESCRIPTION
This makes it easier to reach the UI elements one-handed and prevents the dialog action buttons from shifting.

Fixes: #9