### PR TITLE
RcloneRpc: Fix hang in setRemoteOptions() when setting options for an OAuth2-based backend

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/RcloneRpc.kt
+++ b/app/src/main/java/com/chiller3/rsaf/RcloneRpc.kt
@@ -303,6 +303,9 @@ object RcloneRpc {
                 "name" to remote,
                 "parameters" to options,
                 "opt" to mutableMapOf<String, Any?>(
+                    // This is required or else the rclone authorize flow is triggered, even if we
+                    // don't update any authentication-related options.
+                    "nonInteractive" to true,
                     "obscure" to true,
                 ),
             ),


### PR DESCRIPTION
The `rclone authorize` flow is triggered when updating any option for a backend that uses OAuth2. This causes the thread to hang indefinitely and blocks further RPC calls.

Issue: #16