### PR TITLE
Move rcbridge initialization to RcloneProvider

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/MainApplication.kt
+++ b/app/src/main/java/com/chiller3/rsaf/MainApplication.kt
@@ -37,47 +37,13 @@ class MainApplication : Application(), SharedPreferences.OnSharedPreferenceChang
 
         backupManager = BackupManager(this)
 
-        initRclone()
-
         Logcat.init(this)
 
         // Enable Material You colors
         DynamicColors.applyToActivitiesIfAvailable(this)
     }
 
-    private fun initRclone() {
-        // Some of the rclone backend packages' init() functions set default values based on the
-        // value of config.GetCacheDir(). However, there's no way to call config.SetCacheDir() early
-        // enough that it'll be set before those init() functions. Instead, we'll set the
-        // XDG_CACHE_HOME environment variable to achieve the same effect. Environment variables set
-        // in libc's global environ variable are never read by golang, so rcbridge has an envhack
-        // package to explicitly copy env vars from C land to Go land.
-        Os.setenv("XDG_CACHE_HOME", cacheDir.path, true)
-
-        Rcbridge.rbInit()
-        RcloneConfig.init(this)
-        updateRcloneVerbosity()
-    }
-
-    private fun updateRcloneVerbosity() {
-        val verbosity = if (prefs.isDebugMode) {
-            if (prefs.verboseRcloneLogs) {
-                2L
-            } else {
-                1L
-            }
-        } else {
-            0L
-        }
-        Rcbridge.rbSetLogVerbosity(verbosity)
-    }
-
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
-        when (key) {
-            Preferences.PREF_DEBUG_MODE, Preferences.PREF_VERBOSE_RCLONE_LOGS ->
-                updateRcloneVerbosity()
-        }
-
         Log.i(TAG, "$key preference was changed; notifying backup manager")
         backupManager.dataChanged()
     }


### PR DESCRIPTION
RSAF was previously initializing rcbridge in `MainApplication.onCreate()`. Since all `ContentProvider`s are initialized before the `Application`, it's possible to start receiving `ContentProvider` requests before rcbridge is initialized. This seems to trigger a deadlock in rclone and causes Android to kill RSAF due to the main thread hanging. When hitting this issue, `crash.log` would not be written because the killing is done via `SIGQUIT`, not via a JVM exception. This commit fixes the issue by initializing rcbridge in `RcloneProvider.onCreate()`.

Fixes: #22