### PR TITLE
Block all external app access when remote is hidden

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/EditRemoteDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/EditRemoteDialogFragment.kt
@@ -12,23 +12,23 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 open class EditRemoteDialogFragment : DialogFragment() {
     companion object {
         private const val ARG_REMOTE = "remote"
-        private const val ARG_IS_HIDDEN = "is_hidden"
+        private const val ARG_IS_BLOCKED = "is_blocked"
         const val RESULT_ACTION = "action"
         const val RESULT_REMOTE = "remote"
 
-        fun newInstance(remote: String, remoteHidden: Boolean): EditRemoteDialogFragment =
+        fun newInstance(remote: String, remoteBlocked: Boolean): EditRemoteDialogFragment =
             EditRemoteDialogFragment().apply {
                 arguments = bundleOf(
                     ARG_REMOTE to remote,
-                    ARG_IS_HIDDEN to remoteHidden,
+                    ARG_IS_BLOCKED to remoteBlocked,
                 )
             }
     }
 
     enum class Action {
         OPEN,
-        HIDE,
-        UNHIDE,
+        BLOCK,
+        UNBLOCK,
         CONFIGURE,
         RENAME,
         DUPLICATE,
@@ -36,18 +36,18 @@ open class EditRemoteDialogFragment : DialogFragment() {
     }
 
     private lateinit var remote: String
-    private val remoteHidden by lazy {
-        requireArguments().getBoolean(ARG_IS_HIDDEN)
+    private val remoteBlocked by lazy {
+        requireArguments().getBoolean(ARG_IS_BLOCKED)
     }
     private var action: Action? = null
 
     private val items by lazy {
         mutableListOf<Pair<Action, String>>().apply {
-            if (remoteHidden) {
-                add(Action.UNHIDE to getString(R.string.dialog_edit_remote_unhide_from_documentsui))
+            if (remoteBlocked) {
+                add(Action.UNBLOCK to getString(R.string.dialog_edit_remote_unblock_external_access))
             } else {
                 add(Action.OPEN to getString(R.string.dialog_edit_remote_open_in_documentsui))
-                add(Action.HIDE to getString(R.string.dialog_edit_remote_hide_from_documentsui))
+                add(Action.BLOCK to getString(R.string.dialog_edit_remote_block_external_access))
             }
             add(Action.CONFIGURE to getString(R.string.dialog_edit_remote_action_configure))
             add(Action.RENAME to getString(R.string.dialog_edit_remote_action_rename))

--- a/app/src/main/java/com/chiller3/rsaf/RcloneRpc.kt
+++ b/app/src/main/java/com/chiller3/rsaf/RcloneRpc.kt
@@ -9,7 +9,8 @@ object RcloneRpc {
     private val TAG = RcloneRpc::class.java.simpleName
 
     private const val CUSTOM_OPT_PREFIX = "rsaf:"
-    const val CUSTOM_OPT_HIDDEN = CUSTOM_OPT_PREFIX + "hidden"
+    // This is called hidden due to backwards compatibility.
+    const val CUSTOM_OPT_BLOCKED = CUSTOM_OPT_PREFIX + "hidden"
 
     /**
      * Perform an rclone RPC call.

--- a/app/src/main/java/com/chiller3/rsaf/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/SettingsFragment.kt
@@ -263,11 +263,11 @@ class SettingsFragment : PreferenceFragmentCompat(), FragmentResultListener,
                         }
                         startActivity(intent)
                     }
-                    EditRemoteDialogFragment.Action.HIDE -> {
-                        viewModel.hideRemote(remote, true)
+                    EditRemoteDialogFragment.Action.BLOCK -> {
+                        viewModel.blockRemote(remote, true)
                     }
-                    EditRemoteDialogFragment.Action.UNHIDE -> {
-                        viewModel.hideRemote(remote, false)
+                    EditRemoteDialogFragment.Action.UNBLOCK -> {
+                        viewModel.blockRemote(remote, false)
                     }
                     EditRemoteDialogFragment.Action.CONFIGURE -> {
                         InteractiveConfigurationDialogFragment.newInstance(remote, false)
@@ -343,10 +343,10 @@ class SettingsFragment : PreferenceFragmentCompat(), FragmentResultListener,
             }
             preference.key.startsWith(Preferences.PREF_EDIT_REMOTE_PREFIX) -> {
                 val remote = preference.key.substring(Preferences.PREF_EDIT_REMOTE_PREFIX.length)
-                val isHidden = viewModel.remotes.value.find { it.name == remote }
-                    ?.config?.get(RcloneRpc.CUSTOM_OPT_HIDDEN) == "true"
+                val isBlocked = viewModel.remotes.value.find { it.name == remote }
+                    ?.config?.get(RcloneRpc.CUSTOM_OPT_BLOCKED) == "true"
 
-                EditRemoteDialogFragment.newInstance(remote, isHidden)
+                EditRemoteDialogFragment.newInstance(remote, isBlocked)
                     .show(parentFragmentManager.beginTransaction(), TAG_EDIT_REMOTE)
                 return true
             }
@@ -431,15 +431,15 @@ class SettingsFragment : PreferenceFragmentCompat(), FragmentResultListener,
                 alert.oldRemote, alert.newRemote)
             is RemoteDuplicateFailed -> getString(R.string.alert_duplicate_remote_failure,
                 alert.oldRemote, alert.newRemote, alert.error)
-            is RemoteHideUnhideSucceeded -> if (alert.hidden) {
-                getString(R.string.alert_hide_remote_success, alert.remote)
+            is RemoteBlockUnblockSucceeded -> if (alert.blocked) {
+                getString(R.string.alert_block_remote_success, alert.remote)
             } else {
-                getString(R.string.alert_unhide_remote_success, alert.remote)
+                getString(R.string.alert_unblock_remote_success, alert.remote)
             }
-            is RemoteHideUnhideFailed -> if (alert.hidden) {
-                getString(R.string.alert_hide_remote_failure, alert.remote, alert.error)
+            is RemoteBlockUnblockFailed -> if (alert.block) {
+                getString(R.string.alert_block_remote_failure, alert.remote, alert.error)
             } else {
-                getString(R.string.alert_unhide_remote_failure, alert.remote, alert.error)
+                getString(R.string.alert_unblock_remote_failure, alert.remote, alert.error)
             }
             ImportSucceeded -> getString(R.string.alert_import_success)
             ExportSucceeded -> getString(R.string.alert_export_success)

--- a/app/src/main/java/com/chiller3/rsaf/SettingsViewModel.kt
+++ b/app/src/main/java/com/chiller3/rsaf/SettingsViewModel.kt
@@ -47,11 +47,11 @@ data class RemoteDuplicateFailed(val oldRemote: String, val newRemote: String, v
     override val requireNotifyRootsChanged: Boolean = true
 }
 
-data class RemoteHideUnhideSucceeded(val remote: String, val hidden: Boolean) : Alert {
+data class RemoteBlockUnblockSucceeded(val remote: String, val blocked: Boolean) : Alert {
     override val requireNotifyRootsChanged: Boolean = true
 }
 
-data class RemoteHideUnhideFailed(val remote: String, val hidden: Boolean, val error: String) : Alert {
+data class RemoteBlockUnblockFailed(val remote: String, val block: Boolean, val error: String) : Alert {
     override val requireNotifyRootsChanged: Boolean = false
 }
 object ImportSucceeded : Alert {
@@ -144,19 +144,19 @@ class SettingsViewModel : ViewModel() {
         }
     }
 
-    fun hideRemote(remote: String, hide: Boolean) {
+    fun blockRemote(remote: String, block: Boolean) {
         viewModelScope.launch {
             try {
                 withContext(Dispatchers.IO) {
                     RcloneRpc.setRemoteOptions(remote, mapOf(
-                        RcloneRpc.CUSTOM_OPT_HIDDEN to hide.toString(),
+                        RcloneRpc.CUSTOM_OPT_BLOCKED to block.toString(),
                     ))
                 }
                 refreshRemotesInternal()
-                _alerts.update { it + RemoteHideUnhideSucceeded(remote, hide) }
+                _alerts.update { it + RemoteBlockUnblockSucceeded(remote, block) }
             } catch (e: Exception) {
-                Log.w(TAG, "Failed to set remote $remote hide state to $hide", e)
-                _alerts.update { it + RemoteHideUnhideFailed(remote, hide, e.toString()) }
+                Log.w(TAG, "Failed to set remote $remote block state to $block", e)
+                _alerts.update { it + RemoteBlockUnblockFailed(remote, block, e.toString()) }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,10 +45,10 @@
     <string name="alert_rename_remote_failure">Failed to rename remote %1$s to %2$s: %3$s</string>
     <string name="alert_duplicate_remote_success">Successfully duplicated remote %1$s to %2$s</string>
     <string name="alert_duplicate_remote_failure">Failed to duplicate remote %1$s to %2$s: %3$s</string>
-    <string name="alert_hide_remote_success">Successfully hid remote %1$s from DocumentsUI</string>
-    <string name="alert_hide_remote_failure">Failed to hide remote %1$s from DocumentsUI: %2$s</string>
-    <string name="alert_unhide_remote_success">Successfully unhid remote %1$s from DocumentsUI</string>
-    <string name="alert_unhide_remote_failure">Failed to unhide remote %1$s from DocumentsUI: %2$s</string>
+    <string name="alert_block_remote_success">Successfully blocked external app access to remote %1$s</string>
+    <string name="alert_block_remote_failure">Failed to block external app access to remote %1$s: %2$s</string>
+    <string name="alert_unblock_remote_success">Successfully unblocked external app access to remote %1$s</string>
+    <string name="alert_unblock_remote_failure">Failed to unblock external app access to remote %1$s: %2$s</string>
     <string name="alert_import_success">Successfully imported configuration</string>
     <string name="alert_import_failure">Failed to import configuration: %1$s</string>
     <string name="alert_import_cancelled">Configuration import cancelled</string>
@@ -73,8 +73,8 @@
     <string name="dialog_authorize_message_loading">Waiting for rclone webserver to start.</string>
     <string name="dialog_authorize_message_url">Open the following link to authorize rclone for access to the backend. Once authorized, the token will be automatically inserted in the previous screen.</string>
     <string name="dialog_edit_remote_open_in_documentsui">Open in DocumentsUI</string>
-    <string name="dialog_edit_remote_hide_from_documentsui">Hide from DocumentsUI</string>
-    <string name="dialog_edit_remote_unhide_from_documentsui">Unhide from DocumentsUI</string>
+    <string name="dialog_edit_remote_block_external_access">Block external app access</string>
+    <string name="dialog_edit_remote_unblock_external_access">Unblock external app access</string>
     <string name="dialog_edit_remote_action_configure">Configure remote</string>
     <string name="dialog_edit_remote_action_rename">Rename remote</string>
     <string name="dialog_edit_remote_action_duplicate">Duplicate remote</string>

--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -376,6 +376,24 @@ func getVfsForDoc(doc string) (*vfs.VFS, string, error) {
 	return v, path, nil
 }
 
+type RbRemoteSplitResult struct {
+	Remote string
+	Path   string
+}
+
+func RbRemoteSplit(doc string, errOut *RbError) *RbRemoteSplitResult {
+	remote, path, err := fspath.SplitFs(doc)
+	if err != nil {
+		assignError(errOut, err, syscall.EINVAL)
+		return nil
+	}
+
+	return &RbRemoteSplitResult{
+		Remote: remote,
+		Path:   path,
+	}
+}
+
 type RbPathSplitResult struct {
 	ParentDoc string
 	LeafName  string


### PR DESCRIPTION
Previously, when using the `Hide from DocumentsUI` option, external apps that were previously granted access to a file or directory retain access. This was never the intention.

Now, when a remote is hidden, all further file operations via SAF will fail with a SecurityException. However, the SAF URIs are not revoked so when the remote is unhidden again, apps will immediately regain their prior access. The UI option has been renamed to `Block external app access` to clarify what will actually happen.

Issue: #27