### PR TITLE
Disable arm64 MTE

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,12 +5,14 @@
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
 
+    <!-- MTE is currently disabled because the cgo runtime does not work with it. -->
     <application
         android:name=".MainApplication"
         android:allowBackup="true"
         android:backupAgent=".ConfigBackupAgent"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:memtagMode="off"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"


### PR DESCRIPTION
The cgo runtime currently does not work with MTE enabled. While the Pixel 8 series don't enable MTE by default, if the user chooses to do so, best not to let RSAF crash.