### PR TITLE
isChildDocument(): Normalize paths before comparison

### DIFF
--- a/app/src/androidTest/java/com/chiller3/rsaf/RcloneProviderTest.kt
+++ b/app/src/androidTest/java/com/chiller3/rsaf/RcloneProviderTest.kt
@@ -259,8 +259,14 @@ class RcloneProviderTest {
         assertTrue(isChild(docUriFromRoot(), docUriFromRoot("nested", "child")))
         assertTrue(isChild(docUriFromRoot("dir"), docUriFromRoot("dir", "child")))
         assertTrue(isChild(docUriFromRoot("dir"), docUriFromRoot("dir", "nested", "child")))
-        assertFalse(isChild(docUriFromRoot(), docUriFromRoot()))
-        assertFalse(isChild(docUriFromRoot("dir"), docUriFromRoot("dir")))
+        assertTrue(isChild(docUriFromRoot(), docUriFromRoot()))
+        assertTrue(isChild(docUriFromRoot("dir"), docUriFromRoot("dir")))
+
+        // Some apps, like X-plore, do their own URI manipulation instead of working with URIs
+        // returned by queryChildDocuments(). In particular, they might add trailing slashes.
+        assertTrue(isChild(docUri("${rootDoc}dir/"), docUriFromRoot("dir", "child")))
+        assertTrue(isChild(docUri("${rootDoc}dir/"), docUri("${rootDoc}dir/child/")))
+        assertTrue(isChild(docUri("${rootDoc}//dir/////"), docUri("${rootDoc}dir///nested//child///")))
     }
 
     @Test


### PR DESCRIPTION
Otherwise, duplicate and trailing slashes can result in an incorrect return value, which breaks apps that perform URI manipulation instead of using URIs returned by SAF.

This commit partially reverts 78cf92a963758a0a22f8ff0b71c53be5b189a731 also. If the parent and child refer to the same path, isChildDocuments() will now return true. This is counter to what the SAF documentation says, but AOSP's FileSystemProvider behaves this way and apps now rely on that behavior.

Fixes: #44