### PR TITLE
Fix tests with last rclone upgrade

### DIFF
--- a/app/src/androidTest/java/com/chiller3/rsaf/ImportExportTest.kt
+++ b/app/src/androidTest/java/com/chiller3/rsaf/ImportExportTest.kt
@@ -69,7 +69,8 @@ class ImportExportTest {
             when (option.name) {
                 "type" -> iq.submit("alias")
                 "remote" -> iq.submit(target)
-                else -> throw IllegalStateException("Unexpected question: $option")
+                "config_fs_advanced" -> iq.submit("false")
+                else -> throw IllegalStateException("Unexpected question: ${option.name}")
             }
         }
 

--- a/app/src/androidTest/java/com/chiller3/rsaf/RcloneProviderTest.kt
+++ b/app/src/androidTest/java/com/chiller3/rsaf/RcloneProviderTest.kt
@@ -120,7 +120,8 @@ class RcloneProviderTest {
             when (option.name) {
                 "type" -> iq.submit("alias")
                 "remote" -> iq.submit(rootDir.toString())
-                else -> throw IllegalStateException("Unexpected question: $option")
+                "config_fs_advanced" -> iq.submit("false")
+                else -> throw IllegalStateException("Unexpected question: ${option.name}")
             }
         }
 
@@ -464,7 +465,7 @@ class RcloneProviderTest {
 
                 renamedUri = DocumentsContract.renameDocument(
                     appContext.contentResolver, childDirUri2!!, "dir")
-                assertNull(renamedUri)
+                assertEquals(childDirUri, renamedUri)
             }
         }
     }


### PR DESCRIPTION
* `alias` remotes now ask the `config_fs_advanced` question, so we need to provide an answer when setting up the test remotes.
* In POSIX semantics mode, renaming a directory on top of an empty directory is now allowed (matching local filesystem behavior).