### PR TITLE
Authorizer: Avoid cancelling the log parser on success

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/Authorizer.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Authorizer.kt
@@ -69,7 +69,6 @@ object Authorizer {
                 }
 
                 Log.d(TAG, "Stopped authorize server")
-                cancelLogReader()
             }.apply { start() }
 
             try {
@@ -149,12 +148,15 @@ object Authorizer {
                     } else if (line.contains(MARKER_CODE_STOP)) {
                         inCode = false
                         listener.onAuthorizeCode(code.toString())
+                        break
                     } else if (inCode) {
                         code.append(line)
                     }
                 }
             }
         }
+
+        Log.d(TAG, "Stopped log parser")
     }
 
     private fun cancelLogReader() {


### PR DESCRIPTION
Instead, let the log parser stop itself when it sees `MARKER_CODE_STOP`, which will always be present for the success flow.

The previous behavior of explicitly cancelling the log parser when `Rcbridge.rbAuthorize()` returns is unfortunately prone to a race condition. It turns out that logging from the golang side is not synchronous, so the log message containing the token would sometimes occur after the cancellation message.

Fixes: #55