### PR TITLE
rcbridge: Avoid calling Android functions over JNI

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/RcloneProvider.kt
@@ -396,11 +396,11 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
         val error = RbError()
 
         return MatrixCursor(getDocumentProjection(projection)).apply {
-            if (!Rcbridge.rbDocIterDir(parentDocumentId, error) {
-                addRowByDirEntry(newRow(), it)
-                true
-            }) {
-                throw error.toException("rbIterDir")
+            val entries = Rcbridge.rbDocListDir(parentDocumentId, error)
+                ?: throw error.toException("rbDocListDir")
+
+            for (i in 0 until entries.size()) {
+                addRowByDirEntry(newRow(), entries.get(i))
             }
 
             val uri = DocumentsContract.buildChildDocumentsUri(


### PR DESCRIPTION
Since go 1.22.5, this results in a panic. There is an upstream bug report at [1] for musl, but the same thing happens with bionic. The same fix of using pthread_getattr_np() on bionic also works, but it's better to avoid needing folks to recompile the go toolchain.

We were just using these calls as a small hack to pass a list of structs to the Java side, which we can easily do another way.

[1] https://github.com/golang/go/issues/68285