### PR TITLE
Make dynamic shortcuts configurable

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/EditRemoteDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/EditRemoteDialogFragment.kt
@@ -13,14 +13,20 @@ open class EditRemoteDialogFragment : DialogFragment() {
     companion object {
         private const val ARG_REMOTE = "remote"
         private const val ARG_IS_BLOCKED = "is_blocked"
+        private const val ARG_HAS_SHORTCUT = "has_shortcut"
         const val RESULT_ACTION = "action"
         const val RESULT_REMOTE = "remote"
 
-        fun newInstance(remote: String, remoteBlocked: Boolean): EditRemoteDialogFragment =
+        fun newInstance(
+            remote: String,
+            remoteBlocked: Boolean,
+            hasShortcut: Boolean
+        ): EditRemoteDialogFragment =
             EditRemoteDialogFragment().apply {
                 arguments = bundleOf(
                     ARG_REMOTE to remote,
                     ARG_IS_BLOCKED to remoteBlocked,
+                    ARG_HAS_SHORTCUT to hasShortcut,
                 )
             }
     }
@@ -29,6 +35,8 @@ open class EditRemoteDialogFragment : DialogFragment() {
         OPEN,
         BLOCK,
         UNBLOCK,
+        ADD_SHORTCUT,
+        REMOVE_SHORTCUT,
         CONFIGURE,
         RENAME,
         DUPLICATE,
@@ -39,20 +47,28 @@ open class EditRemoteDialogFragment : DialogFragment() {
     private val remoteBlocked by lazy {
         requireArguments().getBoolean(ARG_IS_BLOCKED)
     }
+    private val hasShortcut by lazy {
+        requireArguments().getBoolean(ARG_HAS_SHORTCUT)
+    }
     private var action: Action? = null
 
     private val items by lazy {
-        mutableListOf<Pair<Action, String>>().apply {
+        mutableListOf<Pair<Action, Int>>().apply {
             if (remoteBlocked) {
-                add(Action.UNBLOCK to getString(R.string.dialog_edit_remote_unblock_external_access))
+                add(Action.UNBLOCK to R.string.dialog_edit_remote_unblock_external_access)
             } else {
-                add(Action.OPEN to getString(R.string.dialog_edit_remote_open_in_documentsui))
-                add(Action.BLOCK to getString(R.string.dialog_edit_remote_block_external_access))
+                add(Action.OPEN to R.string.dialog_edit_remote_open_in_documentsui)
+                add(Action.BLOCK to R.string.dialog_edit_remote_block_external_access)
+                if (hasShortcut) {
+                    add(Action.REMOVE_SHORTCUT to R.string.dialog_edit_remote_remove_dynamic_shortcut)
+                } else {
+                    add(Action.ADD_SHORTCUT to R.string.dialog_edit_remote_add_dynamic_shortcut)
+                }
             }
-            add(Action.CONFIGURE to getString(R.string.dialog_edit_remote_action_configure))
-            add(Action.RENAME to getString(R.string.dialog_edit_remote_action_rename))
-            add(Action.DUPLICATE to getString(R.string.dialog_edit_remote_action_duplicate))
-            add(Action.DELETE to getString(R.string.dialog_edit_remote_action_delete))
+            add(Action.CONFIGURE to R.string.dialog_edit_remote_action_configure)
+            add(Action.RENAME to R.string.dialog_edit_remote_action_rename)
+            add(Action.DUPLICATE to R.string.dialog_edit_remote_action_duplicate)
+            add(Action.DELETE to R.string.dialog_edit_remote_action_delete)
         }
     }
 
@@ -62,7 +78,7 @@ open class EditRemoteDialogFragment : DialogFragment() {
 
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(remote)
-            .setItems(items.map { it.second }.toTypedArray()) { _, i ->
+            .setItems(items.map { getString(it.second) }.toTypedArray()) { _, i ->
                 action = items[i].first
                 dismiss()
             }

--- a/app/src/main/java/com/chiller3/rsaf/RcloneRpc.kt
+++ b/app/src/main/java/com/chiller3/rsaf/RcloneRpc.kt
@@ -11,6 +11,7 @@ object RcloneRpc {
     private const val CUSTOM_OPT_PREFIX = "rsaf:"
     // This is called hidden due to backwards compatibility.
     const val CUSTOM_OPT_BLOCKED = CUSTOM_OPT_PREFIX + "hidden"
+    const val CUSTOM_OPT_DYNAMIC_SHORTCUT = CUSTOM_OPT_PREFIX + "dynamic_shortcut"
 
     /**
      * Perform an rclone RPC call.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,10 @@
     <string name="alert_block_remote_failure">Failed to block external app access to remote %1$s: %2$s</string>
     <string name="alert_unblock_remote_success">Successfully unblocked external app access to remote %1$s</string>
     <string name="alert_unblock_remote_failure">Failed to unblock external app access to remote %1$s: %2$s</string>
+    <string name="alert_add_shortcut_success">Successfully added launcher shortcut for remote: %1$s</string>
+    <string name="alert_add_shortcut_failure">Failed to add launcher shortcut for remote %1$s: %2$s</string>
+    <string name="alert_remove_shortcut_success">Successfully removed launcher shortcut for remote: %1$s</string>
+    <string name="alert_remove_shortcut_failure">Failed to remove launcher shortcut for remote %1$s: %2$s</string>
     <string name="alert_import_success">Successfully imported configuration</string>
     <string name="alert_import_failure">Failed to import configuration: %1$s</string>
     <string name="alert_import_cancelled">Configuration import cancelled</string>
@@ -82,6 +86,8 @@
     <string name="dialog_edit_remote_open_in_documentsui">Open in DocumentsUI</string>
     <string name="dialog_edit_remote_block_external_access">Block external app access</string>
     <string name="dialog_edit_remote_unblock_external_access">Unblock external app access</string>
+    <string name="dialog_edit_remote_add_dynamic_shortcut">Add to launcher shortcuts</string>
+    <string name="dialog_edit_remote_remove_dynamic_shortcut">Remove from launcher shortcuts</string>
     <string name="dialog_edit_remote_action_configure">Configure remote</string>
     <string name="dialog_edit_remote_action_rename">Rename remote</string>
     <string name="dialog_edit_remote_action_duplicate">Duplicate remote</string>


### PR DESCRIPTION
This way, the user can choose which remotes they want shortcuts for. Previously, the visibility was tied to whether external app access was blocked. The default state for this new option is to not add a shortcut. The state is saved in rclone.conf so it is preserved when exporting and reimporting a config.

This commit also fixes RSAF crashing when the number of shortcuts exceeds Android's limit (usually 15). If there are too many shortcuts, the list will now be silently truncated. There is no UI warning for this because the user-facing limit is the launcher's limit (usually 4), which is way less than Android's limit and there's no API for querying it. It doesn't make sense to show a warning long after the launcher already started hiding shortcuts.

Fixes: #65