### PR TITLE
Notify about background uploads and keep process alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ RSAF is not itself a file manager, but any file manager supporting SAF, includin
 
 * Although RSAF always allows random writes, not all backends support it.
 
-    * In this situation, files may be temporarily buffered to disk before they are uploaded. This is the same behavior as with `rclone mount --vfs-cache-mode writes`.
+    * In this situation, files are temporarily buffered to disk before they are uploaded. This is the same behavior as with `rclone mount --vfs-cache-mode writes`.
 
 * Fancier file descriptor system calls are not supported.
 
@@ -76,11 +76,11 @@ With POSIX-like semantics, RSAF follows the behavior of the underlying filesyste
 
 3. That's it! The configured remotes are now available via the Storage Access Framework.
 
-On some devices, Android may kill RSAF while it is running in the background and streaming data to another app (for example, when playing a large video file). https://dontkillmyapp.com/ has instructions for how to disable battery optimization features for various OEMs.
-
 ## Permissions
 
 The only permission RSAF requires is the `INTERNET` permission. It is used only to allow rclone to access the configured remotes. RSAF does not and will never have ads or telemetry.
+
+Allowing notifications and disabling battery optimizations are optional, but strongly recommended. These are needed to allow RSAF to reliably run in the background after a client app closes a file, which is when file uploads actually begin.
 
 On Android 11+, RSAF can optionally request the `MANAGE_EXTERNAL_STORAGE` (All files) permission. This allows rclone to access files in `/sdcard`, which may be useful for wrapper remotes. For example, this allows using a `crypt` remote to transparently encrypt and decrypt files in a local directory.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"
+        android:minSdkVersion="34" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <!-- MTE is currently disabled because the cgo runtime does not work with it. -->
     <application
@@ -39,5 +44,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".BackgroundUploadMonitorService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/com/chiller3/rsaf/BackgroundUploadMonitorService.kt
+++ b/app/src/main/java/com/chiller3/rsaf/BackgroundUploadMonitorService.kt
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.rsaf
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.ServiceCompat
+
+class BackgroundUploadMonitorService : Service() {
+    companion object {
+        private val TAG = BackgroundUploadMonitorService::class.java.simpleName
+
+        private val ACTION_ADD = "${BackgroundUploadMonitorService::class.java.canonicalName}.add"
+        private val ACTION_REMOVE = "${BackgroundUploadMonitorService::class.java.canonicalName}.remove"
+
+        private const val EXTRA_DOCUMENT_ID = "document_id"
+
+        fun createAddIntent(context: Context, documentId: String) =
+            Intent(context, BackgroundUploadMonitorService::class.java).apply {
+                this.action = ACTION_ADD
+                putExtra(EXTRA_DOCUMENT_ID, documentId)
+            }
+
+        fun createRemoveIntent(context: Context, documentId: String) =
+            Intent(context, BackgroundUploadMonitorService::class.java).apply {
+                this.action = ACTION_REMOVE
+                putExtra(EXTRA_DOCUMENT_ID, documentId)
+            }
+    }
+
+    private lateinit var notifications: Notifications
+    private val backgroundUploads = mutableSetOf<String>()
+
+    override fun onCreate() {
+        super.onCreate()
+
+        notifications = Notifications(this)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d(TAG, "Received intent: $intent")
+
+        when (intent?.action) {
+            ACTION_ADD -> {
+                val documentId = intent.getStringExtra(EXTRA_DOCUMENT_ID)!!
+                backgroundUploads.add(documentId)
+            }
+            ACTION_REMOVE -> {
+                val documentId = intent.getStringExtra(EXTRA_DOCUMENT_ID)!!
+                backgroundUploads.remove(documentId)
+            }
+        }
+
+        // This service literally does nothing. It just keeps the process alive for rclone.
+        if (backgroundUploads.isEmpty()) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf(startId)
+        } else {
+            val notification = notifications.createBackgroundUploadsNotification(backgroundUploads.size)
+            val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            } else {
+                0
+            }
+
+            ServiceCompat.startForeground(this, Notifications.ID_BACKGROUND_UPLOADS, notification, type)
+        }
+
+        return START_NOT_STICKY
+    }
+}

--- a/app/src/main/java/com/chiller3/rsaf/MainApplication.kt
+++ b/app/src/main/java/com/chiller3/rsaf/MainApplication.kt
@@ -37,6 +37,8 @@ class MainApplication : Application(), SharedPreferences.OnSharedPreferenceChang
 
         Logcat.init(this)
 
+        Notifications(this).updateChannels()
+
         // Enable Material You colors
         DynamicColors.applyToActivitiesIfAvailable(this)
     }

--- a/app/src/main/java/com/chiller3/rsaf/Notifications.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Notifications.kt
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.rsaf
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+
+class Notifications(private val context: Context) {
+    companion object {
+        private const val CHANNEL_ID_BACKGROUND_UPLOADS = "background_uploads"
+        private const val CHANNEL_ID_FAILURE = "failure"
+
+        private val LEGACY_CHANNEL_IDS = arrayOf<String>()
+
+        const val ID_BACKGROUND_UPLOADS = 1
+    }
+
+    private val prefs = Preferences(context)
+    private val notificationManager = context.getSystemService(NotificationManager::class.java)
+
+    /** Create a low priority notification channel for the background uploads notification. */
+    private fun createBackgroundUploadsChannel() = NotificationChannel(
+        CHANNEL_ID_BACKGROUND_UPLOADS,
+        context.getString(R.string.notification_channel_background_uploads_name),
+        NotificationManager.IMPORTANCE_LOW,
+    ).apply {
+        description = context.getString(R.string.notification_channel_background_uploads_desc)
+    }
+
+    /** Create a high priority notification channel for failure alerts. */
+    private fun createFailureAlertsChannel() = NotificationChannel(
+        CHANNEL_ID_FAILURE,
+        context.getString(R.string.notification_channel_failure_name),
+        NotificationManager.IMPORTANCE_HIGH,
+    ).apply {
+        description = context.getString(R.string.notification_channel_failure_desc)
+    }
+
+    /**
+     * Ensure notification channels are up-to-date.
+     *
+     * Legacy notification channels are deleted without migrating settings.
+     */
+    fun updateChannels() {
+        notificationManager.createNotificationChannels(listOf(
+            createBackgroundUploadsChannel(),
+            createFailureAlertsChannel(),
+        ))
+        LEGACY_CHANNEL_IDS.forEach { notificationManager.deleteNotificationChannel(it) }
+    }
+
+    fun createBackgroundUploadsNotification(count: Int): Notification {
+        val title = context.resources.getQuantityString(
+            R.plurals.notification_background_uploads_in_progress_title,
+            count,
+            count,
+        )
+
+        return Notification.Builder(context, CHANNEL_ID_BACKGROUND_UPLOADS).run {
+            setContentTitle(title)
+            setSmallIcon(R.drawable.ic_notifications)
+            setOngoing(true)
+            setOnlyAlertOnce(true)
+            setProgress(0, 0, true)
+
+            // Inhibit 10-second delay when showing persistent notification
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+            }
+
+            build()
+        }
+    }
+
+    fun notifyBackgroundUploadFailed(documentId: String, errorMsg: String) {
+        val notificationId = prefs.nextNotificationId
+
+        val notification = Notification.Builder(context, CHANNEL_ID_FAILURE).run {
+            val text = buildString {
+                val errorMsgTrimmed = errorMsg.trim()
+                if (errorMsgTrimmed.isNotBlank()) {
+                    append(errorMsgTrimmed)
+                }
+                append("\n\n")
+                append(documentId)
+            }
+
+            setContentTitle(context.getString(R.string.notification_background_upload_failed_title))
+            if (text.isNotBlank()) {
+                setContentText(text)
+                style = Notification.BigTextStyle().bigText(text)
+            }
+            setSmallIcon(R.drawable.ic_notifications)
+
+            build()
+        }
+
+        notificationManager.notify(notificationId, notification)
+    }
+}

--- a/app/src/main/java/com/chiller3/rsaf/Permissions.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Permissions.kt
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.rsaf
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.core.content.ContextCompat
+
+object Permissions {
+    private val NOTIFICATION: Array<String> =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            arrayOf()
+        }
+
+    val REQUIRED: Array<String> = NOTIFICATION
+
+    /** Check if all permissions have been granted. */
+    fun haveRequired(context: Context): Boolean = REQUIRED.all {
+        ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+    }
+
+    /** Check if battery optimizations are currently disabled for this app. */
+    fun isInhibitingBatteryOpt(context: Context): Boolean {
+        val pm: PowerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        return pm.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    /** Get intent for opening the app info page in the system settings. */
+    fun getAppInfoIntent(context: Context) = Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        Uri.fromParts("package", context.packageName, null),
+    )
+
+    /** Get intent for requesting the disabling of battery optimization for this app. */
+    @SuppressLint("BatteryLife")
+    fun getInhibitBatteryOptIntent(context: Context) = Intent(
+        Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+        Uri.fromParts("package", context.packageName, null),
+    )
+}

--- a/app/src/main/java/com/chiller3/rsaf/Preferences.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Preferences.kt
@@ -5,8 +5,9 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 
-class Preferences(context: Context) {
+class Preferences(private val context: Context) {
     companion object {
+        const val CATEGORY_PERMISSIONS = "permissions"
         const val CATEGORY_CONFIGURATION = "configuration"
         const val CATEGORY_DEBUG = "debug"
         const val CATEGORY_REMOTES = "remotes"
@@ -21,6 +22,8 @@ class Preferences(context: Context) {
         const val PREF_VERBOSE_RCLONE_LOGS = "verbose_rclone_logs"
 
         // UI actions only
+        const val PREF_INHIBIT_BATTERY_OPT = "inhibit_battery_opt"
+        const val PREF_MISSING_NOTIFICATIONS = "missing_notifications"
         const val PREF_ADD_REMOTE = "add_remote"
         const val PREF_EDIT_REMOTE_PREFIX = "edit_remote_"
         const val PREF_IMPORT_CONFIGURATION = "import_configuration"
@@ -30,6 +33,7 @@ class Preferences(context: Context) {
 
         // Not associated with a UI preference
         const val PREF_DEBUG_MODE = "debug_mode"
+        private const val PREF_NEXT_NOTIFICATION_ID = "next_notification_id"
     }
 
     private val prefs = PreferenceManager.getDefaultSharedPreferences(context)
@@ -80,4 +84,12 @@ class Preferences(context: Context) {
     var verboseRcloneLogs: Boolean
         get() = prefs.getBoolean(PREF_VERBOSE_RCLONE_LOGS, false)
         set(enabled) = prefs.edit { putBoolean(PREF_VERBOSE_RCLONE_LOGS, enabled) }
+
+    /** Get a unique notification ID that increments on every call. */
+    val nextNotificationId: Int
+        get() = synchronized(context.applicationContext) {
+            val nextId = prefs.getInt(PREF_NEXT_NOTIFICATION_ID, 0)
+            prefs.edit { putInt(PREF_NEXT_NOTIFICATION_ID, nextId + 1) }
+            nextId
+        }
 }

--- a/app/src/main/java/com/chiller3/rsaf/ThrowableExtensions.kt
+++ b/app/src/main/java/com/chiller3/rsaf/ThrowableExtensions.kt
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.rsaf
+
+fun Throwable.toSingleLineString() = buildString {
+    var current: Throwable? = this@toSingleLineString
+    var first = true
+
+    while (current != null) {
+        if (first) {
+            first = false
+        } else {
+            append(" -> ")
+        }
+
+        append(current.javaClass.simpleName)
+
+        val message = current.localizedMessage
+        if (!message.isNullOrBlank()) {
+            append(" (")
+            append(message)
+            append(")")
+        }
+
+        current = current.cause
+    }
+}

--- a/app/src/main/res/drawable/ic_notifications.xml
+++ b/app/src/main/res/drawable/ic_notifications.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <group
+        android:scaleX="0.4"
+        android:scaleY="0.4"
+        android:pivotX="24"
+        android:pivotY="24"
+        android:translateX="-12"
+        android:translateY="-12">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M22.85 26.5h9.05q1.2 0 2.05-.85.85-.85.85-2.05 0-1.2-.85-2.075-.85-.875-2.05-.875h-.6l-.1-.5q-.2-1.55-1.4-2.6T27 16.5q-1.3 0-2.4.65-1.1.65-1.5 1.8l-.1.35h-.4q-1.45 0-2.425 1.075Q19.2 21.45 19.2 22.9t1.075 2.525Q21.35 26.5 22.85 26.5ZM5 42q-1.2 0-2.1-.9Q2 40.2 2 39V10.5h3V39h36.5v3Zm6-6q-1.2 0-2.1-.9Q8 34.2 8 33V7q0-1.2.9-2.1Q9.8 4 11 4h13l3 3h16q1.2 0 2.1.9.9.9.9 2.1v23q0 1.2-.9 2.1-.9.9-2.1.9Zm0-3h32V10H25.75l-3-3H11v26Zm0 0V7v26Z" />
+    </group>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Preference headers -->
+    <string name="pref_header_permissions">Permissions</string>
     <string name="pref_header_remotes">Remotes</string>
     <string name="pref_header_configuration">Configuration</string>
     <string name="pref_header_behavior">Behavior</string>
@@ -9,6 +10,10 @@
     <string name="pref_header_debug">Debug</string>
 
     <!-- Preferences -->
+    <string name="pref_inhibit_battery_opt_name">Disable battery optimization</string>
+    <string name="pref_inhibit_battery_opt_desc">Needed to upload files in the background.</string>
+    <string name="pref_missing_notifications_name">Missing notification permission</string>
+    <string name="pref_missing_notifications_desc">Needed to show when files are being uploaded in the background.</string>
     <string name="pref_add_remote_name">Add a remote</string>
     <string name="pref_add_remote_desc">Add a new rclone remote configuration.</string>
     <string name="pref_import_configuration_name">Import configuration</string>
@@ -105,4 +110,15 @@
     <string name="ic_text_box_helper_required">Value must not be empty.</string>
     <string name="ic_text_box_helper_not_required">Value can be empty.</string>
     <string name="ic_header_examples">Example options:</string>
+
+    <!-- Notifications -->
+    <string name="notification_channel_background_uploads_name">Background uploads</string>
+    <string name="notification_channel_background_uploads_desc">Show in-progress background uploads</string>
+    <string name="notification_channel_failure_name">Failure alerts</string>
+    <string name="notification_channel_failure_desc">Alerts for errors during background uploads</string>
+    <plurals name="notification_background_uploads_in_progress_title">
+        <item quantity="one">Uploading %d file to remote</item>
+        <item quantity="other">Uploading %d files to remotes</item>
+    </plurals>
+    <string name="notification_background_upload_failed_title">Failed to upload file to remote</string>
 </resources>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -1,5 +1,25 @@
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory
+        app:key="permissions"
+        app:title="@string/pref_header_permissions"
+        app:iconSpaceReserved="false">
+
+        <Preference
+            app:key="inhibit_battery_opt"
+            app:persistent="false"
+            app:title="@string/pref_inhibit_battery_opt_name"
+            app:summary="@string/pref_inhibit_battery_opt_desc"
+            app:iconSpaceReserved="false" />
+
+        <Preference
+            app:key="missing_notifications"
+            app:persistent="false"
+            app:title="@string/pref_missing_notifications_name"
+            app:summary="@string/pref_missing_notifications_desc"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         app:key="remotes"
         app:title="@string/pref_header_remotes"
         app:iconSpaceReserved="false">


### PR DESCRIPTION
This commit significantly improves the reliability of running rclone's VFS cache flushing process, especially when writing large files. During `close()`, a foreground service will now be spawned to keep the process alive until the background uploads are complete. However, due to rclone not exposing any information about the VFS cache state in the API, we can only show how many files are currently being closed/uploaded without any additional details.

This has been tested with a background upload of a large file with the screen off that took 23 minutes to complete.

For this to work, the user must enable inhibiting battery optimizations and allow notifications. New UI preferences have been added for both of these. If the user does not want notifications, they can disable the individual notification channels (even all of them if desired).

This commit also adds a new error notification that is shown if `close()` fails.