### PR TITLE
Add support for disabling VFS caching

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/Preferences.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Preferences.kt
@@ -45,6 +45,7 @@ class Preferences(private val context: Context) {
         const val PREF_DELETE_REMOTE = "delete_remote"
         const val PREF_ALLOW_EXTERNAL_ACCESS = "allow_external_access"
         const val PREF_DYNAMIC_SHORTCUT = "dynamic_shortcut"
+        const val PREF_VFS_CACHING = "vfs_caching"
 
         // Not associated with a UI preference
         const val PREF_DEBUG_MODE = "debug_mode"

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
@@ -377,7 +377,7 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
             val config = configs[remote]
                 ?: throw IllegalArgumentException("Remote does not exist: $remote")
 
-            if (config[RcloneRpc.CUSTOM_OPT_BLOCKED] == "true") {
+            if (RcloneRpc.getCustomBoolOpt(config, RcloneRpc.CUSTOM_OPT_BLOCKED)) {
                 throw SecurityException("Access to remote is blocked: $remote")
             }
         }
@@ -393,7 +393,7 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
             }
 
             for ((remote, config) in RcloneRpc.remotes) {
-                if (config[RcloneRpc.CUSTOM_OPT_BLOCKED] == "true") {
+                if (RcloneRpc.getCustomBoolOpt(config, RcloneRpc.CUSTOM_OPT_BLOCKED)) {
                     debugLog("Skipping blocked remote: $remote")
                     continue
                 }

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneRpc.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneRpc.kt
@@ -18,6 +18,11 @@ object RcloneRpc {
     // This is called hidden due to backwards compatibility.
     const val CUSTOM_OPT_BLOCKED = CUSTOM_OPT_PREFIX + "hidden"
     const val CUSTOM_OPT_DYNAMIC_SHORTCUT = CUSTOM_OPT_PREFIX + "dynamic_shortcut"
+    const val CUSTOM_OPT_VFS_CACHING = CUSTOM_OPT_PREFIX + "vfs_caching"
+
+    private const val DEFAULT_BLOCKED = false
+    private const val DEFAULT_DYNAMIC_SHORTCUT = false
+    private const val DEFAULT_VFS_CACHING = true
 
     /**
      * Perform an rclone RPC call.
@@ -385,5 +390,17 @@ object RcloneRpc {
         val output = invoke("core/obscure", JSONObject(mapOf("clear" to password)))
 
         return output.getString("obscured")
+    }
+
+    /** Get the custom option boolean value or return the default if unset or invalid. */
+    fun getCustomBoolOpt(config: Map<String, String>, opt: String): Boolean {
+        val default = when (opt) {
+            CUSTOM_OPT_BLOCKED -> DEFAULT_BLOCKED
+            CUSTOM_OPT_DYNAMIC_SHORTCUT -> DEFAULT_DYNAMIC_SHORTCUT
+            CUSTOM_OPT_VFS_CACHING -> DEFAULT_VFS_CACHING
+            else -> throw IllegalArgumentException("Invalid custom option: $opt")
+        }
+
+        return config[opt]?.toBooleanStrictOrNull() ?: default
     }
 }

--- a/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteAlert.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteAlert.kt
@@ -27,4 +27,6 @@ sealed interface EditRemoteAlert {
     data class UpdateExternalAccessFailed(val remote: String, val error: String) : EditRemoteAlert
 
     data class UpdateDynamicShortcutFailed(val remote: String, val error: String) : EditRemoteAlert
+
+    data class UpdateVfsCachingFailed(val remote: String, val error: String) : EditRemoteAlert
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,10 @@
     <string name="pref_edit_remote_allow_external_access_desc">Allow external apps to access this remote via the system file manager. Access is not needed if this remote is just a backend for another remote.</string>
     <string name="pref_edit_remote_dynamic_shortcut_name">Show in launcher shortcuts</string>
     <string name="pref_edit_remote_dynamic_shortcut_desc">Include this remote in the list of shortcuts when long pressing RSAF\'s launcher icon.</string>
+    <string name="pref_edit_remote_vfs_caching_name">Enable VFS caching</string>
+    <string name="pref_edit_remote_vfs_caching_desc_loading">(Checking if streaming is supported…)</string>
+    <string name="pref_edit_remote_vfs_caching_desc_optional">VFS caching enables support for random writes and allows failed uploads to be retried. However, files do not begin uploading until the client app closes them.</string>
+    <string name="pref_edit_remote_vfs_caching_desc_required">VFS caching cannot be disabled because this remote type does not support streaming uploads.</string>
 
     <!-- Main alerts -->
     <string name="alert_list_remotes_failure">Failed to get list of remotes: %1$s</string>
@@ -82,6 +86,7 @@
     <string name="alert_duplicate_remote_failure">Failed to duplicate remote %1$s to %2$s: %3$s</string>
     <string name="alert_update_external_access_failure">Failed to update external app access to remote %1$s: %2$s</string>
     <string name="alert_update_dynamic_shortcut_failure">Failed to update launcher shortcut for remote %1$s: %2$s</string>
+    <string name="alert_update_vfs_caching_failure">Failed to update VFS caching for remote %1$s: %2$s</string>
 
     <!-- Biometric -->
     <string name="biometric_title">Unlock configuration</string>

--- a/app/src/main/res/xml/preferences_edit_remote.xml
+++ b/app/src/main/res/xml/preferences_edit_remote.xml
@@ -52,7 +52,8 @@
             app:persistent="false"
             app:title="@string/pref_edit_remote_allow_external_access_name"
             app:summary="@string/pref_edit_remote_allow_external_access_desc"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:defaultValue="true" />
 
         <SwitchPreferenceCompat
             app:key="dynamic_shortcut"
@@ -60,5 +61,12 @@
             app:title="@string/pref_edit_remote_dynamic_shortcut_name"
             app:summary="@string/pref_edit_remote_dynamic_shortcut_desc"
             app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            app:key="vfs_caching"
+            app:persistent="false"
+            app:title="@string/pref_edit_remote_vfs_caching_name"
+            app:iconSpaceReserved="false"
+            app:defaultValue="true" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
VFS caching can now be configured per-remote. Disabling it is equivalent to `rclone mount --vfs-cache-mode none`. This will disable support for random writes and prevent failed uploads from being retried. However, it allows uploads to begin immediately and allows the client to show more accurate file write progress.

If a remote type does not support streaming, VFS caching will be force enabled and the UI option will be grayed out. This is preferable to allowing the user to set a broken configuration and not knowing until they try to create a file and having it fail.

Internally, RSAF now maintains two sets of VFS instances. One set with caching VFSs and another set with streaming VFSs. This allows the caching option to be toggled immediately without waiting for open files to be closed (and fully uploaded). The downside is that if the user toggles the option while uploads are occurring, the directory listings may be inconsistent until the uploads complete.

Issue: #79