### PR TITLE
BackgroundUploadMonitorService: Guess and show upload progress

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/rclone/BackgroundUploadMonitorService.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/BackgroundUploadMonitorService.kt
@@ -10,10 +10,18 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
+import android.os.ParcelFileDescriptor
+import android.system.ErrnoException
+import android.system.Os
+import android.system.OsConstants
 import android.util.Log
+import androidx.annotation.UiThread
 import androidx.core.app.ServiceCompat
 import com.chiller3.rsaf.Notifications
+import java.io.File
 
 class BackgroundUploadMonitorService : Service() {
     companion object {
@@ -35,15 +43,54 @@ class BackgroundUploadMonitorService : Service() {
                 this.action = ACTION_REMOVE
                 putExtra(EXTRA_DOCUMENT_ID, documentId)
             }
+
+        private fun getFdPosAndSize(fd: Int): Pair<Long, Long> =
+            // We dup() the fd to ensure that the pos and size at least refer to the same file.
+            ParcelFileDescriptor.fromFd(fd).use { pfd ->
+                val pos = Os.lseek(pfd.fileDescriptor, 0, OsConstants.SEEK_CUR)
+                val size = pfd.statSize
+
+                pos to size
+            }
     }
 
     private lateinit var notifications: Notifications
     private val backgroundUploads = mutableSetOf<String>()
+    private lateinit var dataDataDir: File
+    private lateinit var vfsCacheDir: File
+    private val monitorThread = Thread(::monitorVfsCache)
+    @Volatile
+    private var monitorCanRun = false
+    private var monitorNotify = false
+    private var monitorProgress = 0L to 0L
+    private val handler = Handler(Looper.getMainLooper())
+
+    private fun normalizePath(path: File): File {
+        // Can't use relativeToOrNull() because it can add `..` components.
+        return if (path.startsWith(dataDataDir)) {
+            val relPath = path.relativeTo(dataDataDir)
+            File(dataDir, relPath.path)
+        } else {
+            path
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()
 
         notifications = Notifications(this)
+
+        dataDataDir = File("/data/data", packageName)
+        vfsCacheDir = normalizePath(File(cacheDir, "rclone/vfs"))
+
+        monitorThread.start()
+        monitorCanRun = true
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        monitorCanRun = false
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -62,21 +109,79 @@ class BackgroundUploadMonitorService : Service() {
             }
         }
 
-        // This service literally does nothing. It just keeps the process alive for rclone.
+        monitorNotify = backgroundUploads.isNotEmpty()
+
         if (backgroundUploads.isEmpty()) {
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf(startId)
         } else {
-            val notification = notifications.createBackgroundUploadsNotification(backgroundUploads.size)
-            val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
-            } else {
-                0
-            }
-
-            ServiceCompat.startForeground(this, Notifications.ID_BACKGROUND_UPLOADS, notification, type)
+            updateForegroundNotification()
         }
 
         return START_NOT_STICKY
+    }
+
+    @UiThread
+    private fun updateForegroundNotification() {
+        val notification = notifications.createBackgroundUploadsNotification(
+            backgroundUploads.size,
+            monitorProgress.first,
+            monitorProgress.second,
+        )
+        val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+        } else {
+            0
+        }
+
+        ServiceCompat.startForeground(this, Notifications.ID_BACKGROUND_UPLOADS, notification, type)
+    }
+
+    private fun guessVfsCacheProgress(): Pair<Long, Long> {
+        val procfsFd = File("/proc/self/fd")
+
+        var totalPos = 0L
+        var totalSize = 0L
+
+        for (file in procfsFd.listFiles() ?: emptyArray()) {
+            val fd = file.name.toInt()
+
+            val target = try {
+                normalizePath(File(Os.readlink(file.toString())))
+            } catch (e: ErrnoException) {
+                continue
+            }
+
+            if (!target.startsWith(vfsCacheDir)) {
+                continue
+            }
+
+            val (filePos, fileSize) = try {
+                getFdPosAndSize(fd)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to query fd $fd", e)
+                continue
+            }
+
+            totalPos += filePos
+            totalSize += fileSize
+        }
+
+        return totalPos to totalSize
+    }
+
+    private fun monitorVfsCache() {
+        while (monitorCanRun) {
+            val progress = guessVfsCacheProgress()
+
+            handler.post {
+                if (monitorNotify) {
+                    monitorProgress = progress
+                    updateForegroundNotification()
+                }
+            }
+
+            Thread.sleep(1000)
+        }
     }
 }


### PR DESCRIPTION
Unfortunately, rclone has no APIs, internal or otherwise, for querying the upload progress for the VFS writeback cache. We'll do it ourselves the hacky way by scanning all open file descriptors for open files in the VFS cache directory and grab the current file positions and sizes.

Issue: #79