### PR TITLE
PreferenceBaseActivity: Add support for legacy device credential auth

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <!-- Biometric -->
     <string name="biometric_title">Unlock configuration</string>
     <string name="biometric_error">Biometric authentication error: %1$s</string>
+    <string name="biometric_error_no_device_credential">No device credential</string>
     <string name="biometric_failure">Biometric authentication failed</string>
 
     <!-- Dialogs -->


### PR DESCRIPTION
Although androidx.biometric can handle biometric auth on legacy Android versions, we're intentionally not using it. The legacy device credential API does both biometric and device credential auth and it is not possible to disable just the biometric part, so just let the legacy API handle everything.

Issue: #93