### PR TITLE
Work around setOnApplyWindowInsetsListener in older Android versions

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/PreferenceBaseActivity.kt
+++ b/app/src/main/java/com/chiller3/rsaf/PreferenceBaseActivity.kt
@@ -106,7 +106,14 @@ abstract class PreferenceBaseActivity : AppCompatActivity() {
                 rightMargin = insets.right
             }
 
-            WindowInsetsCompat.CONSUMED
+            // Consuming the insets here prevents PreferenceBaseFragment's RecyclerView's insets
+            // callback from being called on older versions of Android, despite it not being a child
+            // of this view.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                WindowInsetsCompat.CONSUMED
+            } else {
+                windowInsets
+            }
         }
 
         setSupportActionBar(binding.toolbar)


### PR DESCRIPTION
On older Android versions (at least API 29 and 30), the window insets callback on the RecyclerView is never called if the MaterialToolbar consumes the insets, even though the RecyclerView is not its child.

Issue: #93