### PR TITLE
SettingsFragment: Remove MIME type filter when selecting file for import

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/SettingsFragment.kt
@@ -361,9 +361,9 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
                 return true
             }
             preference === prefImportConfiguration -> {
-                // Android does not recognize .conf suffix as a text file
-                requestSafImportConfiguration.launch(
-                    arrayOf(RcloneConfig.MIMETYPE, "application/octet-stream"))
+                // We intentionally do not filter for specific MIME types because document providers
+                // are inconsistent in what MIME types they report for .conf files.
+                requestSafImportConfiguration.launch(arrayOf("*/*"))
                 return true
             }
             preference === prefExportConfiguration -> {


### PR DESCRIPTION
While Android's builtin FileSystemProvider for local files guesses the MIME type based on the file extension, other document providers may not do so and could report something other than application/octet-stream or text/plain. Let's just let the user select any file.

Issue: #93