### PR TITLE
PreferenceBaseActivity: Don't abort when first biometric auth attempt fails

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/PreferenceBaseActivity.kt
+++ b/app/src/main/java/com/chiller3/rsaf/PreferenceBaseActivity.kt
@@ -58,7 +58,10 @@ abstract class PreferenceBaseActivity : AppCompatActivity() {
                 onAuthenticationSucceeded()
             } else {
                 // We can't know the reason.
-                onAuthenticationFailed()
+                onAuthenticationError(
+                    BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL,
+                    getString(R.string.biometric_error_no_device_credential),
+                )
             }
         }
 
@@ -135,8 +138,10 @@ abstract class PreferenceBaseActivity : AppCompatActivity() {
                 override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) =
                     this@PreferenceBaseActivity.onAuthenticationSucceeded()
 
-                override fun onAuthenticationFailed() =
-                    this@PreferenceBaseActivity.onAuthenticationFailed()
+                override fun onAuthenticationFailed() {
+                    // Ignore. This is called when a single biometric authentication attempt fails,
+                    // but the user is still allowed to retry.
+                }
             },
         )
 
@@ -279,18 +284,6 @@ abstract class PreferenceBaseActivity : AppCompatActivity() {
 
         bioAuthenticated = true
         refreshGlobalVisibility()
-    }
-
-    private fun onAuthenticationFailed() {
-        Log.d(tag, "Authentication failed")
-
-        Toast.makeText(
-            this,
-            R.string.biometric_failure,
-            Toast.LENGTH_LONG,
-        ).show()
-
-        finish()
     }
 
     private fun refreshTaskState() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,7 +92,6 @@
     <string name="biometric_title">Unlock configuration</string>
     <string name="biometric_error">Biometric authentication error: %1$s</string>
     <string name="biometric_error_no_device_credential">No device credential</string>
-    <string name="biometric_failure">Biometric authentication failed</string>
 
     <!-- Dialogs -->
     <string name="dialog_action_next">Next</string>


### PR DESCRIPTION
The previous behavior of failing after the first try is just annoying, especially when using the fingerprint reader. We'll just ignore the per-attempt error. If the user fails to authenticate too many times, Android will lock them out anyway.