### PR TITLE
Add support for reporting filesystem usage per-remote

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/Preferences.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Preferences.kt
@@ -46,6 +46,7 @@ class Preferences(private val context: Context) {
         const val PREF_ALLOW_EXTERNAL_ACCESS = "allow_external_access"
         const val PREF_DYNAMIC_SHORTCUT = "dynamic_shortcut"
         const val PREF_VFS_CACHING = "vfs_caching"
+        const val PREF_REPORT_USAGE = "report_usage"
 
         // Not associated with a UI preference
         const val PREF_DEBUG_MODE = "debug_mode"

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
@@ -424,6 +424,13 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
                     continue
                 }
 
+                val usage = if (RcloneRpc.getCustomBoolOpt(config, RcloneRpc.CUSTOM_OPT_REPORT_USAGE)) {
+                    debugLog("Querying filesystem usage: $remote")
+                    RcloneRpc.getUsage("$remote:")
+                } else {
+                    null
+                }
+
                 newRow().apply {
                     // Required
                     add(DocumentsContract.Root.COLUMN_ROOT_ID, remote)
@@ -434,6 +441,15 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
 
                     // Optional
                     add(DocumentsContract.Root.COLUMN_SUMMARY, remote)
+
+                    usage?.total?.let {
+                        debugLog("Remote reports total space: $remote: $it")
+                        add(DocumentsContract.Root.COLUMN_CAPACITY_BYTES, it)
+                    }
+                    usage?.free?.let {
+                        debugLog("Remote reports free space: $remote: $it")
+                        add(DocumentsContract.Root.COLUMN_AVAILABLE_BYTES, it)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteAlert.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteAlert.kt
@@ -24,9 +24,9 @@ sealed interface EditRemoteAlert {
         val error: String,
     ) : EditRemoteAlert
 
-    data class UpdateExternalAccessFailed(val remote: String, val error: String) : EditRemoteAlert
-
-    data class UpdateDynamicShortcutFailed(val remote: String, val error: String) : EditRemoteAlert
-
-    data class UpdateVfsCachingFailed(val remote: String, val error: String) : EditRemoteAlert
+    data class SetConfigFailed(
+        val remote: String,
+        val opt: String,
+        val error: String,
+    ) : EditRemoteAlert
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,10 @@
     <string name="pref_edit_remote_vfs_caching_desc_loading">(Checking if streaming is supported…)</string>
     <string name="pref_edit_remote_vfs_caching_desc_optional">VFS caching enables support for random writes and allows failed uploads to be retried. However, files do not begin uploading until the client app closes them.</string>
     <string name="pref_edit_remote_vfs_caching_desc_required">VFS caching cannot be disabled because this remote type does not support streaming uploads.</string>
+    <string name="pref_edit_remote_report_usage_name">Report filesystem usage</string>
+    <string name="pref_edit_remote_report_usage_desc_loading">(Checking if filesystem usage reporting is supported…)</string>
+    <string name="pref_edit_remote_report_usage_desc_supported">Report free space and total space to client apps. For some remote types, this can significantly slow down client apps when they fetch the list of remotes.</string>
+    <string name="pref_edit_remote_report_usage_desc_unsupported">This remote type does not support reporting its free space and total space.</string>
 
     <!-- Main alerts -->
     <string name="alert_list_remotes_failure">Failed to get list of remotes: %1$s</string>
@@ -84,9 +88,7 @@
     <string name="alert_delete_remote_failure">Failed to delete %1$s: %2$s</string>
     <string name="alert_rename_remote_failure">Failed to rename remote %1$s to %2$s: %3$s</string>
     <string name="alert_duplicate_remote_failure">Failed to duplicate remote %1$s to %2$s: %3$s</string>
-    <string name="alert_update_external_access_failure">Failed to update external app access to remote %1$s: %2$s</string>
-    <string name="alert_update_dynamic_shortcut_failure">Failed to update launcher shortcut for remote %1$s: %2$s</string>
-    <string name="alert_update_vfs_caching_failure">Failed to update VFS caching for remote %1$s: %2$s</string>
+    <string name="alert_set_config_failure">Failed to set %1$s config option for remote %2$s: %3$s</string>
 
     <!-- Biometric -->
     <string name="biometric_title">Unlock configuration</string>

--- a/app/src/main/res/xml/preferences_edit_remote.xml
+++ b/app/src/main/res/xml/preferences_edit_remote.xml
@@ -68,5 +68,11 @@
             app:title="@string/pref_edit_remote_vfs_caching_name"
             app:iconSpaceReserved="false"
             app:defaultValue="true" />
+
+        <SwitchPreferenceCompat
+            app:key="report_usage"
+            app:persistent="false"
+            app:title="@string/pref_edit_remote_report_usage_name"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -438,14 +438,26 @@ func getVfsForDoc(doc string) (*vfs.VFS, string, error) {
 	return v, path, nil
 }
 
+type RbRemoteFeaturesResult struct {
+	PutStream bool
+	About     bool
+}
+
 // Return whether the specified remote supports streaming.
-func RbCanStream(remote string) (bool, error) {
+func RbRemoteFeatures(remote string) (*RbRemoteFeaturesResult, error) {
 	f, err := getFs(remote)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	return f.Features().PutStream != nil, nil
+	features := f.Features()
+
+	result := RbRemoteFeaturesResult{
+		PutStream: features.PutStream != nil,
+		About:     features.About != nil,
+	}
+
+	return &result, nil
 }
 
 type RbRemoteSplitResult struct {


### PR DESCRIPTION
This is disabled by default because some remotes are extremely slow at computing the filesystem usage. Google Drive, in particular, sometimes takes 30 seconds or more to return a result, even with a near empty drive.