### PR TITLE
RcloneProvider: Don't notify on close() errors for read-only files

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
@@ -860,10 +860,16 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
             if (!handle.close(error)) {
                 val exception = error.toException("RbFile.close")
 
-                // This method is not supposed to throw
+                // This method is not supposed to throw.
                 Log.w(TAG, "Error when closing file", exception)
 
-                notifications.notifyBackgroundUploadFailed(documentId, exception.toSingleLineString())
+                // Don't notify if the file is read only. There would have been no data loss anyway.
+                if (isWrite) {
+                    notifications.notifyBackgroundUploadFailed(
+                        documentId,
+                        exception.toSingleLineString(),
+                    )
+                }
             }
 
             if (isWrite && Permissions.isInhibitingBatteryOpt(context)) {


### PR DESCRIPTION
When apps hold file descriptors open long after they stopped reading from them, the rclone backend network connections may have timed out. This isn't reported until `close()` is called. This was observed with at least the SFTP backend, but may occur with others too.

Since closing a read-only file has no impact on the data whatsoever, let's just hide the errors.