### PR TITLE
Spawn a foreground service when files are open

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,11 @@
             android:exported="false" />
 
         <service
+            android:name=".rclone.OpenFilesService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false" />
+
+        <service
             android:name=".rclone.BackgroundUploadMonitorService"
             android:foregroundServiceType="specialUse"
             android:exported="false" />

--- a/app/src/main/java/com/chiller3/rsaf/rclone/OpenFilesService.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/OpenFilesService.kt
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.rsaf.rclone
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import androidx.annotation.UiThread
+import androidx.core.app.ServiceCompat
+import com.chiller3.rsaf.Notifications
+
+/**
+ * A dumb service to keep the process alive while files are open because ContentProviders don't get
+ * special treatment, even when another process is actively using a file descriptor from it.
+ */
+class OpenFilesService : Service() {
+    companion object {
+        private val TAG = OpenFilesService::class.java.simpleName
+
+        private val ACTION_INCREMENT = "${OpenFilesService::class.java.canonicalName}.increment"
+        private val ACTION_DECREMENT = "${OpenFilesService::class.java.canonicalName}.decrement"
+
+        fun createIncrementIntent(context: Context) =
+            Intent(context, OpenFilesService::class.java).apply {
+                action = ACTION_INCREMENT
+            }
+
+        fun createDecrementIntent(context: Context) =
+            Intent(context, OpenFilesService::class.java).apply {
+                action = ACTION_DECREMENT
+            }
+    }
+
+    private lateinit var notifications: Notifications
+    private var openFiles = 0
+    private val handler = Handler(Looper.getMainLooper())
+    // We need to keep a reference the same runnable for cancelling a delayed execution.
+    private val stopNowRunnable = Runnable(::stopNow)
+
+    override fun onCreate() {
+        super.onCreate()
+
+        notifications = Notifications(this)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d(TAG, "Received intent: $intent")
+
+        when (intent?.action) {
+            ACTION_INCREMENT -> openFiles += 1
+            ACTION_DECREMENT -> openFiles -= 1
+        }
+
+        if (openFiles == 0) {
+            // We'll defer the stopping of the service by a small amount of time to avoid having
+            // notifications rapidly appear and disappear when opening many small files. We can't
+            // use FOREGROUND_SERVICE_DEFERRED because that is ignored if a deferral has already
+            // happened recently.
+            handler.postDelayed(stopNowRunnable, 1000)
+        } else {
+            handler.removeCallbacks(stopNowRunnable)
+            updateForegroundNotification()
+        }
+
+        return START_NOT_STICKY
+    }
+
+    private fun stopNow() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    @UiThread
+    private fun updateForegroundNotification() {
+        val notification = notifications.createOpenFilesNotification(openFiles)
+        val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+        } else {
+            0
+        }
+
+        ServiceCompat.startForeground(this, Notifications.ID_OPEN_FILES, notification, type)
+    }
+}

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
@@ -791,6 +791,12 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
     ) : ProxyFileDescriptorCallback() {
         init {
             markUsed()
+
+            val context = context!!
+
+            if (Permissions.isInhibitingBatteryOpt(context)) {
+                context.startForegroundService(OpenFilesService.createIncrementIntent(context))
+            }
         }
 
         private fun debugLog(msg: String) {
@@ -850,10 +856,14 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
 
             val context = context!!
 
-            if (isWrite && Permissions.isInhibitingBatteryOpt(context)) {
-                context.startForegroundService(
-                    BackgroundUploadMonitorService.createAddIntent(context, documentId),
-                )
+            if (Permissions.isInhibitingBatteryOpt(context)) {
+                context.startForegroundService(OpenFilesService.createDecrementIntent(context))
+
+                if (isWrite) {
+                    context.startForegroundService(
+                        BackgroundUploadMonitorService.createIncrementIntent(context),
+                    )
+                }
             }
 
             val error = RbError()
@@ -874,7 +884,7 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
 
             if (isWrite && Permissions.isInhibitingBatteryOpt(context)) {
                 context.startForegroundService(
-                    BackgroundUploadMonitorService.createRemoveIntent(context, documentId),
+                    BackgroundUploadMonitorService.createDecrementIntent(context),
                 )
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,10 +124,16 @@
     <string name="ic_header_examples">Example options:</string>
 
     <!-- Notifications -->
+    <string name="notification_channel_open_files_name">Open files</string>
+    <string name="notification_channel_open_files_desc">Keeps process alive while files are open</string>
     <string name="notification_channel_background_uploads_name">Background uploads</string>
     <string name="notification_channel_background_uploads_desc">Show in-progress background uploads</string>
     <string name="notification_channel_failure_name">Failure alerts</string>
     <string name="notification_channel_failure_desc">Alerts for errors during background uploads</string>
+    <plurals name="notification_open_files_title">
+        <item quantity="one">%d open file</item>
+        <item quantity="other">%d open files</item>
+    </plurals>
     <plurals name="notification_background_uploads_in_progress_title">
         <item quantity="one">Uploading %d file to remote</item>
         <item quantity="other">Uploading %d files to remotes</item>


### PR DESCRIPTION
`ContentProvider`s don't get special treatment in Android, so the RSAF process can be frozen or killed even while a client app has a file descriptor open and is actively using it. This commit works around the problem by spawning a no-op foreground service when there are open file descriptors.