### PR TITLE
Add support for hiding files on a remote when the app is locked

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/Preferences.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Preferences.kt
@@ -47,6 +47,7 @@ class Preferences(private val context: Context) {
         const val PREF_DUPLICATE_REMOTE = "duplicate_remote"
         const val PREF_DELETE_REMOTE = "delete_remote"
         const val PREF_ALLOW_EXTERNAL_ACCESS = "allow_external_access"
+        const val PREF_ALLOW_LOCKED_ACCESS = "allow_locked_access"
         const val PREF_DYNAMIC_SHORTCUT = "dynamic_shortcut"
         const val PREF_VFS_CACHING = "vfs_caching"
         const val PREF_REPORT_USAGE = "report_usage"

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneRpc.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneRpc.kt
@@ -16,12 +16,14 @@ object RcloneRpc {
 
     private const val CUSTOM_OPT_PREFIX = "rsaf:"
     // This is called hidden due to backwards compatibility.
-    const val CUSTOM_OPT_BLOCKED = CUSTOM_OPT_PREFIX + "hidden"
+    const val CUSTOM_OPT_HARD_BLOCKED = CUSTOM_OPT_PREFIX + "hidden"
+    const val CUSTOM_OPT_SOFT_BLOCKED = CUSTOM_OPT_PREFIX + "soft_blocked"
     const val CUSTOM_OPT_DYNAMIC_SHORTCUT = CUSTOM_OPT_PREFIX + "dynamic_shortcut"
     const val CUSTOM_OPT_VFS_CACHING = CUSTOM_OPT_PREFIX + "vfs_caching"
     const val CUSTOM_OPT_REPORT_USAGE = CUSTOM_OPT_PREFIX + "report_usage"
 
-    private const val DEFAULT_BLOCKED = false
+    private const val DEFAULT_HARD_BLOCKED = false
+    private const val DEFAULT_SOFT_BLOCKED = false
     private const val DEFAULT_DYNAMIC_SHORTCUT = false
     private const val DEFAULT_VFS_CACHING = true
     private const val DEFAULT_REPORT_USAGE = false
@@ -397,7 +399,8 @@ object RcloneRpc {
     /** Get the custom option boolean value or return the default if unset or invalid. */
     fun getCustomBoolOpt(config: Map<String, String>, opt: String): Boolean {
         val default = when (opt) {
-            CUSTOM_OPT_BLOCKED -> DEFAULT_BLOCKED
+            CUSTOM_OPT_HARD_BLOCKED -> DEFAULT_HARD_BLOCKED
+            CUSTOM_OPT_SOFT_BLOCKED -> DEFAULT_SOFT_BLOCKED
             CUSTOM_OPT_DYNAMIC_SHORTCUT -> DEFAULT_DYNAMIC_SHORTCUT
             CUSTOM_OPT_VFS_CACHING -> DEFAULT_VFS_CACHING
             CUSTOM_OPT_REPORT_USAGE -> DEFAULT_REPORT_USAGE

--- a/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteViewModel.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteViewModel.kt
@@ -27,6 +27,7 @@ data class EditRemoteActivityActions(
 
 data class RemoteConfigState(
     val allowExternalAccess: Boolean? = null,
+    val allowLockedAccess: Boolean? = null,
     val dynamicShortcut: Boolean? = null,
     val vfsCaching: Boolean? = null,
     val reportUsage: Boolean? = null,
@@ -72,7 +73,11 @@ class EditRemoteViewModel : ViewModel() {
                     it.copy(
                         allowExternalAccess = !RcloneRpc.getCustomBoolOpt(
                             config,
-                            RcloneRpc.CUSTOM_OPT_BLOCKED,
+                            RcloneRpc.CUSTOM_OPT_HARD_BLOCKED,
+                        ),
+                        allowLockedAccess = !RcloneRpc.getCustomBoolOpt(
+                            config,
+                            RcloneRpc.CUSTOM_OPT_SOFT_BLOCKED,
                         ),
                         dynamicShortcut = RcloneRpc.getCustomBoolOpt(
                             config,
@@ -135,9 +140,13 @@ class EditRemoteViewModel : ViewModel() {
     }
 
     fun setExternalAccess(remote: String, allow: Boolean) {
-        setCustomOpt(remote, RcloneRpc.CUSTOM_OPT_BLOCKED, !allow) {
+        setCustomOpt(remote, RcloneRpc.CUSTOM_OPT_HARD_BLOCKED, !allow) {
             _activityActions.update { it.copy(refreshRoots = true) }
         }
+    }
+
+    fun setLockedAccess(remote: String, allow: Boolean) {
+        setCustomOpt(remote, RcloneRpc.CUSTOM_OPT_SOFT_BLOCKED, !allow)
     }
 
     fun setDynamicShortcut(remote: String, enabled: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,9 @@
     <string name="pref_edit_remote_delete_desc">Remove this remote from the configuration.</string>
     <string name="pref_edit_remote_allow_external_access_name">Allow external app access</string>
     <string name="pref_edit_remote_allow_external_access_desc">Allow external apps to access this remote via the system file manager. Access is not needed if this remote is just a backend for another remote.</string>
+    <string name="pref_edit_remote_allow_locked_access_name">Allow access while locked</string>
+    <string name="pref_edit_remote_allow_locked_access_desc_on">While RSAF is locked, files are still available to external apps that have been granted access.</string>
+    <string name="pref_edit_remote_allow_locked_access_desc_off">While RSAF is locked, files are hidden from external apps and new file operations are blocked. Ongoing operations with files that are already open are unaffected.</string>
     <string name="pref_edit_remote_dynamic_shortcut_name">Show in launcher shortcuts</string>
     <string name="pref_edit_remote_dynamic_shortcut_desc">Include this remote in the list of shortcuts when long pressing RSAF\'s launcher icon.</string>
     <string name="pref_edit_remote_vfs_caching_name">Enable VFS caching</string>

--- a/app/src/main/res/xml/preferences_edit_remote.xml
+++ b/app/src/main/res/xml/preferences_edit_remote.xml
@@ -56,6 +56,15 @@
             app:defaultValue="true" />
 
         <SwitchPreferenceCompat
+            app:key="allow_locked_access"
+            app:persistent="false"
+            app:title="@string/pref_edit_remote_allow_locked_access_name"
+            app:summaryOn="@string/pref_edit_remote_allow_locked_access_desc_on"
+            app:summaryOff="@string/pref_edit_remote_allow_locked_access_desc_off"
+            app:iconSpaceReserved="false"
+            app:defaultValue="true" />
+
+        <SwitchPreferenceCompat
             app:key="dynamic_shortcut"
             app:persistent="false"
             app:title="@string/pref_edit_remote_dynamic_shortcut_name"


### PR DESCRIPTION
This commit adds a new per-remote option for hiding files while the app is locked. This is implemented as an extension of the existing allow external access toggle. However, with this option:

* The SAF roots remain visible
* File operations throw `FileNotFoundException` instead of `SecurityException`

The idea is that external apps are temporarily blocked from access, but still retain all previously granted permissions.

Unlike the original proposed design, `queryChildDocuments()` will also throw `FileNotFoundException` instead of returning an empty list. This is so the same function is used for enforce all security restrictions and make it easy to verify the correctness of the logic.

When the inactivity period expires, the restrictions are enforced for new file operations only. Ongoing operations, like file copies/moves, and reads/writes against already-open file descriptors are still allowed.

Fixes: #106