### PR TITLE
Add support for resuming VFS cache writeback

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ With POSIX-like semantics, RSAF follows the behavior of the underlying filesyste
 
 ## Permissions
 
-The only permission RSAF requires is the `INTERNET` permission. It is used only to allow rclone to access the configured remotes. RSAF does not and will never have ads or telemetry.
+The main permission RSAF requires is the `INTERNET` permission. It is used only to allow rclone to access the configured remotes. RSAF does not and will never have ads or telemetry.
+
+The `RECEIVE_BOOT_COMPLETED` permission is used to automatically resume pending uploads if they were interrupted due to a crash or reboot.
 
 Allowing notifications and disabling battery optimizations are optional, but strongly recommended. These are needed to allow RSAF to reliably run in the background after a client app closes a file, which is when file uploads actually begin.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <!-- MTE is currently disabled because the cgo runtime does not work with it. -->
@@ -59,6 +60,15 @@
             android:name=".rclone.OpenFilesService"
             android:foregroundServiceType="specialUse"
             android:exported="false" />
+
+        <receiver
+            android:name=".rclone.BackgroundUploadMonitorReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <service
             android:name=".rclone.BackgroundUploadMonitorService"

--- a/app/src/main/java/com/chiller3/rsaf/rclone/BackgroundUploadMonitorReceiver.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/BackgroundUploadMonitorReceiver.kt
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.rsaf.rclone
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class BackgroundUploadMonitorReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action != Intent.ACTION_BOOT_COMPLETED) {
+            return
+        }
+
+        BackgroundUploadMonitorService.startWithScanOnce(context)
+    }
+}

--- a/app/src/main/java/com/chiller3/rsaf/rclone/BackgroundUploadMonitorService.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/BackgroundUploadMonitorService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -21,26 +21,39 @@ import android.util.Log
 import androidx.annotation.UiThread
 import androidx.core.app.ServiceCompat
 import com.chiller3.rsaf.Notifications
+import com.chiller3.rsaf.binding.rcbridge.RbError
+import com.chiller3.rsaf.binding.rcbridge.Rcbridge
+import com.chiller3.rsaf.extension.toException
 import java.io.File
 
 class BackgroundUploadMonitorService : Service() {
     companion object {
         private val TAG = BackgroundUploadMonitorService::class.java.simpleName
 
-        private val ACTION_INCREMENT =
-            "${BackgroundUploadMonitorService::class.java.canonicalName}.increment"
-        private val ACTION_DECREMENT =
-            "${BackgroundUploadMonitorService::class.java.canonicalName}.decrement"
+        private const val EXTRA_SCAN_REMOTES = "scan_remotes"
 
-        fun createIncrementIntent(context: Context) =
+        private const val MAX_IDLE_COUNT = 2
+
+        private var startedWithScanOnce = false
+
+        fun createIntent(context: Context, scanRemotes: Boolean) =
             Intent(context, BackgroundUploadMonitorService::class.java).apply {
-                action = ACTION_INCREMENT
+                putExtra(EXTRA_SCAN_REMOTES, scanRemotes)
             }
 
-        fun createDecrementIntent(context: Context) =
-            Intent(context, BackgroundUploadMonitorService::class.java).apply {
-                action = ACTION_DECREMENT
+        /**
+         * Start this service once with remote scanning enabled. This allows rclone to pick up where
+         * it left off if RSAF crashes or is killed by the system. This is called when the user
+         * opens the app and when the device is first unlocked.
+         */
+        fun startWithScanOnce(context: Context) {
+            if (startedWithScanOnce) {
+                Log.d(TAG, "Already started with scan enabled once")
+            } else {
+                startedWithScanOnce = true
+                context.startForegroundService(createIntent(context, true))
             }
+        }
 
         private fun getFdPosAndSize(fd: Int): Pair<Long, Long> =
             // We dup() the fd to ensure that the pos and size at least refer to the same file.
@@ -52,15 +65,29 @@ class BackgroundUploadMonitorService : Service() {
             }
     }
 
+    data class Progress(val count: Int, val bytesCurrent: Long, val bytesTotal: Long)
+
+    private sealed interface MonitorState {
+        data object Inactive : MonitorState
+
+        data object Active : MonitorState
+
+        data class StopAfter(val remain: Int) : MonitorState
+
+        data object Stopped : MonitorState
+    }
+
     private lateinit var notifications: Notifications
-    private var backgroundUploads = 0
     private lateinit var dataDataDir: File
     private lateinit var vfsCacheDir: File
     private val monitorThread = Thread(::monitorVfsCache)
-    @Volatile
-    private var monitorCanRun = false
-    private var monitorNotify = false
-    private var monitorProgress = 0L to 0L
+    private var monitorState: MonitorState = MonitorState.Inactive
+        set(state) {
+            Log.d(TAG, "New monitor state: $state")
+            field = state
+        }
+    private var monitorProgress = Progress(0, 0L, 0L)
+    private var monitorScanRemotes = false
     private val handler = Handler(Looper.getMainLooper())
     // We need to keep a reference the same runnable for cancelling a delayed execution.
     private val stopNowRunnable = Runnable(::stopNow)
@@ -84,13 +111,14 @@ class BackgroundUploadMonitorService : Service() {
         vfsCacheDir = normalizePath(File(cacheDir, "rclone/vfs"))
 
         monitorThread.start()
-        monitorCanRun = true
     }
 
     override fun onDestroy() {
         super.onDestroy()
 
-        monitorCanRun = false
+        synchronized(monitorThread) {
+            monitorState = MonitorState.Stopped
+        }
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -98,23 +126,16 @@ class BackgroundUploadMonitorService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "Received intent: $intent")
 
-        when (intent?.action) {
-            ACTION_INCREMENT -> backgroundUploads += 1
-            ACTION_DECREMENT -> backgroundUploads -= 1
-        }
+        synchronized(monitorThread) {
+            require(monitorState != MonitorState.Stopped)
+            monitorState = MonitorState.Active
 
-        monitorNotify = backgroundUploads != 0
+            monitorScanRemotes = intent?.getBooleanExtra(EXTRA_SCAN_REMOTES, false) == true
 
-        if (backgroundUploads == 0) {
-            // We'll defer the stopping of the service by a small amount of time to avoid having
-            // notifications rapidly appear and disappear when writing many small files. We can't
-            // use FOREGROUND_SERVICE_DEFERRED because that is ignored if a deferral has already
-            // happened recently.
-            handler.postDelayed(stopNowRunnable, 1000)
-        } else {
             handler.removeCallbacks(stopNowRunnable)
-            updateForegroundNotification()
         }
+
+        updateForegroundNotification()
 
         return START_NOT_STICKY
     }
@@ -126,11 +147,8 @@ class BackgroundUploadMonitorService : Service() {
 
     @UiThread
     private fun updateForegroundNotification() {
-        val notification = notifications.createBackgroundUploadsNotification(
-            backgroundUploads,
-            monitorProgress.first,
-            monitorProgress.second,
-        )
+        val progress = synchronized(monitorThread) { monitorProgress }
+        val notification = notifications.createBackgroundUploadsNotification(progress)
         val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
         } else {
@@ -140,9 +158,10 @@ class BackgroundUploadMonitorService : Service() {
         ServiceCompat.startForeground(this, Notifications.ID_BACKGROUND_UPLOADS, notification, type)
     }
 
-    private fun guessVfsCacheProgress(): Pair<Long, Long> {
+    private fun guessVfsCacheProgress(): Progress {
         val procfsFd = File("/proc/self/fd")
 
+        var count = 0
         var totalPos = 0L
         var totalSize = 0L
 
@@ -166,21 +185,105 @@ class BackgroundUploadMonitorService : Service() {
                 continue
             }
 
+            count += 1
             totalPos += filePos
             totalSize += fileSize
         }
 
-        return totalPos to totalSize
+        return Progress(count, totalPos, totalSize)
+    }
+
+    private fun initVfsCacheRemotes() {
+        val neededRemotes = hashSetOf<String>()
+
+        // Only scan remotes that have things in their cache. We don't need to do a recursive
+        // scan because rclone automatically removes empty cache directories.
+        //
+        // NOTE: This is imperfect when using aliases. Specifically with SFTP, the cache paths are
+        // normally relative to the home directory. However, if an alias specifies an absolute path,
+        // then the cache files are relative to the root directory. We have no way to know which is
+        // correct when resuming uploads. Since information about aliases is lost in the VFS cache
+        // directory structure, we always initialize the VFS for the underlying remote. Absolute
+        // file paths will be uploaded to the home directory instead.
+        for (remoteDir in vfsCacheDir.listFiles() ?: emptyArray()) {
+            if ((remoteDir.list()?.size ?: 0) > 0) {
+                neededRemotes.add(remoteDir.name)
+            }
+        }
+
+        Log.d(TAG, "Initializing VFS for remotes: $neededRemotes")
+
+        for ((remote, config) in RcloneRpc.remotes) {
+            if (!neededRemotes.remove(remote)) {
+                continue
+            } else if (!RcloneRpc.getCustomBoolOpt(config, RcloneRpc.CUSTOM_OPT_VFS_CACHING)) {
+                // The user will have to re-enable VFS caching to upload these.
+                continue
+            }
+
+            val error = RbError()
+            if (!Rcbridge.rbDocVfsInit("$remote:", error)) {
+                val e = error.toException("rbDocVfsInit")
+                Log.w(TAG, "Failed to initialize VFS for remote: $remote", e)
+            }
+        }
+
+        Log.d(TAG, "Uninitialized remotes: $neededRemotes")
     }
 
     private fun monitorVfsCache() {
-        while (monitorCanRun) {
+        while (true) {
+            val scan = synchronized(monitorThread) {
+                val scan = monitorScanRemotes
+                monitorScanRemotes = false
+                scan
+            }
+            if (scan) {
+                initVfsCacheRemotes()
+            }
+
             val progress = guessVfsCacheProgress()
 
-            handler.post {
-                if (monitorNotify) {
+            synchronized(monitorThread) {
+                var shouldNotify = false
+                var shouldStop = false
+
+                when (val state = monitorState) {
+                    MonitorState.Inactive -> {}
+                    MonitorState.Active -> {
+                        if (progress.count == 0) {
+                            monitorState = MonitorState.StopAfter(MAX_IDLE_COUNT)
+                        }
+                        shouldNotify = true
+                    }
+                    is MonitorState.StopAfter -> {
+                        monitorState = if (progress.count == 0) {
+                            val remain = state.remain - 1
+                            if (remain > 0) {
+                                MonitorState.StopAfter(remain)
+                            } else {
+                                shouldStop = true
+                                MonitorState.Inactive
+                            }
+                        } else {
+                            shouldNotify = true
+                            MonitorState.Active
+                        }
+                    }
+                    MonitorState.Stopped -> return
+                }
+
+                if (progress == monitorProgress) {
+                    shouldNotify = false
+                } else {
                     monitorProgress = progress
-                    updateForegroundNotification()
+                }
+
+                if (shouldNotify) {
+                    handler.post(::updateForegroundNotification)
+                }
+                if (shouldStop) {
+                    handler.post(stopNowRunnable)
                 }
             }
 

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -29,7 +29,6 @@ import android.util.Size
 import android.webkit.MimeTypeMap
 import com.chiller3.rsaf.AppLock
 import com.chiller3.rsaf.BuildConfig
-import com.chiller3.rsaf.Notifications
 import com.chiller3.rsaf.Permissions
 import com.chiller3.rsaf.Preferences
 import com.chiller3.rsaf.R
@@ -300,7 +299,6 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
     }
 
     private lateinit var prefs: Preferences
-    private lateinit var notifications: Notifications
     private val ioThread = HandlerThread(javaClass.simpleName).apply { start() }
     private val ioHandler = Handler(ioThread.looper)
     // Because it is impossible to make close() blocking, we can't force the client app to wait for
@@ -356,8 +354,6 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
 
         prefs = Preferences(context)
         prefs.registerListener(this)
-
-        notifications = Notifications(context)
 
         // Some of the rclone backend packages' init() functions set default values based on the
         // value of config.GetCacheDir(). However, there's no way to call config.SetCacheDir() early
@@ -908,7 +904,7 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
 
                 if (isWrite) {
                     context.startForegroundService(
-                        BackgroundUploadMonitorService.createIncrementIntent(context),
+                        BackgroundUploadMonitorService.createIntent(context, false),
                     )
                 }
             }
@@ -919,20 +915,6 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
 
                 // This method is not supposed to throw.
                 Log.w(TAG, "Error when closing file", exception)
-
-                // Don't notify if the file is read only. There would have been no data loss anyway.
-                if (isWrite) {
-                    notifications.notifyBackgroundUploadFailed(
-                        documentId,
-                        exception.toSingleLineString(),
-                    )
-                }
-            }
-
-            if (isWrite && Permissions.isInhibitingBatteryOpt(context)) {
-                context.startForegroundService(
-                    BackgroundUploadMonitorService.createDecrementIntent(context),
-                )
             }
 
             markUnused()

--- a/app/src/main/java/com/chiller3/rsaf/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/SettingsFragment.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -39,6 +39,7 @@ import com.chiller3.rsaf.dialog.RemoteNameDialogAction
 import com.chiller3.rsaf.dialog.RemoteNameDialogFragment
 import com.chiller3.rsaf.dialog.TextInputDialogFragment
 import com.chiller3.rsaf.extension.formattedString
+import com.chiller3.rsaf.rclone.BackgroundUploadMonitorService
 import com.chiller3.rsaf.rclone.RcloneConfig
 import com.chiller3.rsaf.rclone.RcloneProvider
 import com.chiller3.rsaf.view.LongClickablePreference
@@ -124,6 +125,8 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
         setPreferencesFromResource(R.xml.preferences_root, rootKey)
 
         val context = requireContext()
+
+        BackgroundUploadMonitorService.startWithScanOnce(context)
 
         prefs = Preferences(context)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,5 +151,4 @@
         <item quantity="one">Uploading %d file to remote</item>
         <item quantity="other">Uploading %d files to remotes</item>
     </plurals>
-    <string name="notification_background_upload_failed_title">Failed to upload file to remote</string>
 </resources>


### PR DESCRIPTION
Previously, if the VFS cache writeback was interrupted, it would effectively not be resumable, especially if the files were big. After the interruption, the first file operation on remotes with pending uploads would block until the uploads completed. However, there would be no foreground service to keep the process alive. The only way to get out of the situation would be to leave the RSAF settings screen open until the uploads invisibly complete.

With this commit, `BackgroundUploadMonitorService` is now also started on boot or when the user first opens the app after it crashes or is killed. It will scan through the VFS cache directory and initialize the VFS instances for remotes with pending uploads. The service now exits on its own after a period of time with no VFS cache files open.

For this to work well, the rclone VFS is configured so that writebacks are asynchronous. This is necessary to prevent VFS initialization from blocking until uploads are complete, but unfortunately also makes the `close()` operation asynchronous. RSAF is no longer able to show a notification if a background upload fails.