### PR TITLE
Remove support for POSIX-like semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ RSAF is not itself a file manager, but any file manager supporting SAF, includin
 * Supports client applications that request access to a file descriptor
 * Supports client applications that open entire directories with `ACTION_OPEN_DOCUMENT_TREE`
 * Supports pretending to be local storage for apps that block remote SAF roots
-* Supports both [Android-like and POSIX-like file operation semantics](#file-operation-semantics)
 * [No required permissions besides network access](#permissions)
 
 ## Limitations
@@ -57,16 +56,7 @@ RSAF is not itself a file manager, but any file manager supporting SAF, includin
 
 ## File operation semantics
 
-RSAF supports operating with either Android-like (default) or POSIX-like semantics.
-
-With Android-like semantics, when creating, renaming, copying, or moving a file/directory, RSAF will add a counter to the filename to try and avoid conflicts (eg. `file(1).txt`) if the target path already exists. This matches the Storage Access Framework's behavior for local files, though RSAF extends this to copying/moving instead of just file creation/renaming. However, this feature cannot be implemented in a completely foolproof way. If two client applications try to create files with the same name at the same time, they still might end up clobbering each other's data, even with the added counter.
-
-With POSIX-like semantics, RSAF follows the behavior of the underlying filesystem calls. It'll behave more like common CLI utilities, such as `mv`, `cp`, or even `rclone` itself.
-
-* Creating a new file/directory behaves like `touch`/`mkdir -p`. If the path already exists and is the same type, the operation will succeed.
-* Renaming a file on top of an existing file will overwrite the existing file. Otherwise, if the target path already exists, the operation will fail.
-* Copying files/directories behaves like `cp -rT`. Files with the same name in the target will be overwritten. Directories will be merged (but conflicting files within directories are still overwritten).
-* Moving paths behaves like copying paths, except that the source is gone once the operation succeeds.
+When creating, renaming, copying, or moving a file/directory, RSAF will add a counter to the filename to try and avoid conflicts (eg. `file(1).txt`) if the target path already exists. This matches the Storage Access Framework's behavior for local files, though RSAF extends this to copying/moving instead of just file creation/renaming. However, this feature cannot be implemented in a completely foolproof way. If two client applications try to create files with the same name at the same time, they still might end up clobbering each other's data, even with the added counter.
 
 ## Usage
 

--- a/app/src/main/java/com/chiller3/rsaf/Notifications.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Notifications.kt
@@ -26,7 +26,6 @@ class Notifications(private val context: Context) {
         const val ID_BACKGROUND_UPLOADS = -2
     }
 
-    private val prefs = Preferences(context)
     private val notificationManager = context.getSystemService(NotificationManager::class.java)
 
     /** Create a low priority notification channel for the open files notification. */

--- a/app/src/main/java/com/chiller3/rsaf/Preferences.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Preferences.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -23,7 +23,6 @@ class Preferences(private val context: Context) {
         const val PREF_ALLOW_BACKUP = "allow_backup"
         const val PREF_DIALOGS_AT_BOTTOM = "dialogs_at_bottom"
         const val PREF_LOCAL_STORAGE_ACCESS = "local_storage_access"
-        const val PREF_POSIX_LIKE_SEMANTICS = "posix_like_semantics"
         const val PREF_PRETEND_LOCAL = "pretend_local"
         const val PREF_REQUIRE_AUTH = "require_auth"
         const val PREF_INACTIVITY_TIMEOUT = "inactivity_timeout"
@@ -80,11 +79,6 @@ class Preferences(private val context: Context) {
     var addFileExtension: Boolean
         get() = prefs.getBoolean(PREF_ADD_FILE_EXTENSION, true)
         set(enabled) = prefs.edit { putBoolean(PREF_ADD_FILE_EXTENSION, enabled) }
-
-    /** Whether to use POSIX-like semantics instead of Android-like semantics. */
-    var posixLikeSemantics: Boolean
-        get() = prefs.getBoolean(PREF_POSIX_LIKE_SEMANTICS, false)
-        set(enabled) = prefs.edit { putBoolean(PREF_POSIX_LIKE_SEMANTICS, enabled) }
 
     /** Whether to falsely advertise all roots as local storage. */
     var pretendLocal: Boolean

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-    SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <resources>
@@ -28,9 +28,6 @@
     <string name="pref_export_configuration_desc">Export current rclone configuration to a file.</string>
     <string name="pref_add_file_extension_name">Add file extension</string>
     <string name="pref_add_file_extension_desc">When creating a new file, automatically add the file extension corresponding to the file type.</string>
-    <string name="pref_posix_like_semantics_name">POSIX-like semantics</string>
-    <string name="pref_posix_like_semantics_desc_on">Use command-line-style file operation behavior. Creating paths that already exist is allowed. Renaming files overwrites existing targets. Copying and moving paths overwrites files and merges directories.</string>
-    <string name="pref_posix_like_semantics_desc_off">Use Android-style file operation behavior. When creating, renaming, copying, or moving paths, add a number to the name to avoid conflicts if the target path already exists.</string>
     <string name="pref_pretend_local_name">Pretend to be local storage</string>
     <string name="pref_pretend_local_desc">Present the rclone remotes as local storage to the Storage Access Framework. This forces compatibility with apps that only allow selecting local files.</string>
     <string name="pref_local_storage_access_name">Allow local storage access</string>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -1,5 +1,5 @@
 <!--
-    SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
@@ -65,13 +65,6 @@
             app:defaultValue="true"
             app:title="@string/pref_add_file_extension_name"
             app:summary="@string/pref_add_file_extension_desc"
-            app:iconSpaceReserved="false" />
-
-        <SwitchPreferenceCompat
-            app:key="posix_like_semantics"
-            app:title="@string/pref_posix_like_semantics_name"
-            app:summaryOn="@string/pref_posix_like_semantics_desc_on"
-            app:summaryOff="@string/pref_posix_like_semantics_desc_off"
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat


### PR DESCRIPTION
This turned out to be not such a great idea. Applications expect document providers to behave like Android's builtin FileSystemProvider for local files. POSIX-like semantics differed significantly from that and there are no known applications that explicitly try to make use of this functionality. Let's get rid of this feature and simplify the code.