### PR TITLE
Make file close operations synchronous again

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/Notifications.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Notifications.kt
@@ -26,6 +26,7 @@ class Notifications(private val context: Context) {
         const val ID_BACKGROUND_UPLOADS = -2
     }
 
+    private val prefs = Preferences(context)
     private val notificationManager = context.getSystemService(NotificationManager::class.java)
 
     /** Create a low priority notification channel for the open files notification. */
@@ -126,5 +127,31 @@ class Notifications(private val context: Context) {
 
             build()
         }
+    }
+
+    fun notifyBackgroundUploadFailed(documentId: String, errorMsg: String) {
+        val notificationId = prefs.nextNotificationId
+
+        val notification = Notification.Builder(context, CHANNEL_ID_FAILURE).run {
+            val text = buildString {
+                val errorMsgTrimmed = errorMsg.trim()
+                if (errorMsgTrimmed.isNotBlank()) {
+                    append(errorMsgTrimmed)
+                }
+                append("\n\n")
+                append(documentId)
+            }
+
+            setContentTitle(context.getString(R.string.notification_background_upload_failed_title))
+            if (text.isNotBlank()) {
+                setContentText(text)
+                style = Notification.BigTextStyle().bigText(text)
+            }
+            setSmallIcon(R.drawable.ic_notifications)
+
+            build()
+        }
+
+        notificationManager.notify(notificationId, notification)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,4 +148,5 @@
         <item quantity="one">Uploading %d file to remote</item>
         <item quantity="other">Uploading %d files to remotes</item>
     </plurals>
+    <string name="notification_background_upload_failed_title">Failed to upload file to remote</string>
 </resources>


### PR DESCRIPTION
In c63e7f494da9091ba650ef94c78977660271d1d9, file close operations were made asynchronous to prevent `vfs.New()` from blocking due to it opening and closing every cached file to trigger pending uploads. This broke the in-use file tracker in `RcloneProvider` and made it impossible for RSAF to report upload errors in most cases.

This commit fixes the problem by keeping the file close operation asynchronous initially and then making it synchronous after the VFS instance is created.

Fixes: #81 (again)