### PR TITLE
Prompt before actions that delete the VFS cache

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/Notifications.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Notifications.kt
@@ -11,7 +11,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
 import android.text.format.Formatter
-import com.chiller3.rsaf.rclone.BackgroundUploadMonitorService
+import com.chiller3.rsaf.rclone.VfsCache
 import kotlin.math.roundToInt
 
 class Notifications(private val context: Context) {
@@ -92,9 +92,7 @@ class Notifications(private val context: Context) {
         }
     }
 
-    fun createBackgroundUploadsNotification(
-        progress: BackgroundUploadMonitorService.Progress,
-    ): Notification {
+    fun createBackgroundUploadsNotification(progress: VfsCache.Progress): Notification {
         val title = context.resources.getQuantityString(
             R.plurals.notification_background_uploads_in_progress_title,
             progress.count,

--- a/app/src/main/java/com/chiller3/rsaf/dialog/VfsCacheDeletionDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/dialog/VfsCacheDeletionDialogFragment.kt
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.rsaf.dialog
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.Gravity
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.chiller3.rsaf.Preferences
+import com.chiller3.rsaf.R
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+class VfsCacheDeletionDialogFragment : DialogFragment() {
+    companion object {
+        private const val ARG_TITLE = "title"
+        const val RESULT_SUCCESS = "success"
+
+        fun newInstance(title: String) = VfsCacheDeletionDialogFragment().apply {
+            arguments = bundleOf(ARG_TITLE to title)
+        }
+    }
+
+    private var success: Boolean = false
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val arguments = requireArguments()
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(arguments.getString(ARG_TITLE))
+            .setMessage(R.string.dialog_vfs_cache_deletion_message)
+            .setPositiveButton(R.string.dialog_action_proceed_anyway) { _, _ ->
+                success = true
+            }
+            .setNegativeButton(R.string.dialog_action_cancel, null)
+            .create()
+            .apply {
+                if (Preferences(requireContext()).dialogsAtBottom) {
+                    window!!.attributes.gravity = Gravity.BOTTOM
+                }
+            }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        setFragmentResult(tag!!, bundleOf(RESULT_SUCCESS to success))
+    }
+}

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
@@ -376,6 +376,7 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
         Rcbridge.rbInit()
         Rcbridge.rbReloadCerts()
         RcloneConfig.init(context)
+        VfsCache.init(context)
         updateRcloneVerbosity()
 
         context.registerReceiver(

--- a/app/src/main/java/com/chiller3/rsaf/rclone/VfsCache.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/VfsCache.kt
@@ -1,0 +1,133 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.rsaf.rclone
+
+import android.content.Context
+import android.os.ParcelFileDescriptor
+import android.system.ErrnoException
+import android.system.Os
+import android.system.OsConstants
+import android.util.Log
+import com.chiller3.rsaf.binding.rcbridge.RbError
+import com.chiller3.rsaf.binding.rcbridge.Rcbridge
+import com.chiller3.rsaf.extension.toException
+import java.io.File
+
+object VfsCache {
+    data class Progress(val count: Int, val bytesCurrent: Long, val bytesTotal: Long)
+
+    private val TAG = VfsCache::class.java.simpleName
+
+    private val procfsFd = File("/proc/self/fd")
+    private lateinit var appDataDir: File
+    private lateinit var dataDataDir: File
+    private lateinit var vfsCacheDir: File
+
+    fun init(context: Context) {
+        appDataDir = context.dataDir
+        dataDataDir = File("/data/data", context.packageName)
+        vfsCacheDir = normalizePath(File(context.cacheDir, "rclone/vfs"))
+    }
+
+    private fun normalizePath(path: File): File {
+        // Can't use relativeToOrNull() because it can add `..` components.
+        return if (path.startsWith(dataDataDir)) {
+            val relPath = path.relativeTo(dataDataDir)
+            File(appDataDir, relPath.path)
+        } else {
+            path
+        }
+    }
+
+    private fun getFdPosAndSize(fd: Int): Pair<Long, Long> =
+        // We dup() the fd to ensure that the pos and size at least refer to the same file.
+        ParcelFileDescriptor.fromFd(fd).use { pfd ->
+            val pos = Os.lseek(pfd.fileDescriptor, 0, OsConstants.SEEK_CUR)
+            val size = pfd.statSize
+
+            pos to size
+        }
+
+    fun guessProgress(remote: String?, withSize: Boolean): Progress {
+        var count = 0
+        var totalPos = 0L
+        var totalSize = 0L
+
+        val prefix = if (remote == null) {
+            vfsCacheDir
+        } else {
+            File(vfsCacheDir, remote)
+        }
+
+        for (file in procfsFd.listFiles() ?: emptyArray()) {
+            val fd = file.name.toInt()
+
+            val target = try {
+                normalizePath(File(Os.readlink(file.toString())))
+            } catch (_: ErrnoException) {
+                continue
+            }
+
+            if (!target.startsWith(prefix)) {
+                continue
+            }
+
+            count += 1
+
+            if (withSize) {
+                val (filePos, fileSize) = try {
+                    getFdPosAndSize(fd)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to query fd $fd", e)
+                    continue
+                }
+
+                totalPos += filePos
+                totalSize += fileSize
+            }
+        }
+
+        return Progress(count, totalPos, totalSize)
+    }
+
+    fun initDirtyRemotes() {
+        val neededRemotes = hashSetOf<String>()
+
+        // Only scan remotes that have things in their cache. We don't need to do a recursive
+        // scan because rclone automatically removes empty cache directories.
+        //
+        // NOTE: This is imperfect when using aliases. Specifically with SFTP, the cache paths are
+        // normally relative to the home directory. However, if an alias specifies an absolute path,
+        // then the cache files are relative to the root directory. We have no way to know which is
+        // correct when resuming uploads. Since information about aliases is lost in the VFS cache
+        // directory structure, we always initialize the VFS for the underlying remote. Absolute
+        // file paths will be uploaded to the home directory instead.
+        for (remoteDir in vfsCacheDir.listFiles() ?: emptyArray()) {
+            if ((remoteDir.list()?.size ?: 0) > 0) {
+                neededRemotes.add(remoteDir.name)
+            }
+        }
+
+        Log.d(TAG, "Initializing VFS for remotes: $neededRemotes")
+
+        for ((remote, config) in RcloneRpc.remotes) {
+            if (!neededRemotes.remove(remote)) {
+                continue
+            } else if (!RcloneRpc.getCustomBoolOpt(config, RcloneRpc.CUSTOM_OPT_VFS_CACHING)) {
+                // The user will have to re-enable VFS caching to upload these.
+                continue
+            }
+
+            val error = RbError()
+            if (!Rcbridge.rbDocVfsInit("$remote:", error)) {
+                val e = error.toException("rbDocVfsInit")
+                Log.w(TAG, "Failed to initialize VFS for remote: $remote", e)
+            }
+        }
+
+        Log.d(TAG, "Uninitialized remotes: $neededRemotes")
+    }
+}

--- a/app/src/main/java/com/chiller3/rsaf/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import com.chiller3.rsaf.Logcat
 import com.chiller3.rsaf.rclone.RcloneConfig
 import com.chiller3.rsaf.rclone.RcloneRpc
+import com.chiller3.rsaf.rclone.VfsCache
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -93,6 +94,10 @@ class SettingsViewModel : ViewModel() {
     fun remoteEdited() {
         refreshRemotes()
     }
+
+    // This performs I/O, but only with the in-memory procfs.
+    val isAnyVfsCacheDirty: Boolean
+        get() = VfsCache.guessProgress(null, false).count > 0
 
     fun startImportExport(mode: ImportExportMode, uri: Uri) {
         if (importExportState.value != null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,11 +109,13 @@
     <string name="dialog_action_cancel">Cancel</string>
     <string name="dialog_action_authorize">Authorize</string>
     <string name="dialog_action_reset">Reset</string>
+    <string name="dialog_action_proceed_anyway">Proceed anyway</string>
     <string name="dialog_remote_name_message">Enter a name for the remote.</string>
     <string name="dialog_remote_name_hint">Remote name</string>
     <string name="dialog_add_remote_title">Add remote</string>
     <string name="dialog_rename_remote_title">Rename %1$s</string>
     <string name="dialog_duplicate_remote_title">Duplicate %1$s</string>
+    <string name="dialog_delete_remote_title">Delete %1$s</string>
     <string name="dialog_authorize_title">Waiting for authorization</string>
     <string name="dialog_authorize_message_loading">Waiting for rclone webserver to start.</string>
     <string name="dialog_authorize_message_url">Open the following link to authorize rclone for access to the backend. Once authorized, the token will be automatically inserted in the previous screen.</string>
@@ -125,6 +127,7 @@
     <string name="dialog_export_password_hint">Encryption password</string>
     <string name="dialog_inactivity_timeout_title">Inactivity timeout</string>
     <string name="dialog_inactivity_timeout_message">Enter a duration in seconds.</string>
+    <string name="dialog_vfs_cache_deletion_message">There are file operations in progress. These operations will be interrupted and pending uploads in the VFS cache will be permanently deleted.</string>
 
     <!-- Interactive configuration -->
     <string name="ic_title_add_remote">Add remote: %1$s</string>


### PR DESCRIPTION
Previously, when deleting a remote, renaming (copy + delete) a remote, or importing a configuration, we'd wait up to 1 minute for pending VFS writeback operations to complete and then delete the remote and VFS cache. This was a terrible user experience because:

* the user does not have the choice to wait for file operations to complete if they weren't already aware of them
* the UI would appear as if nothing was happening
* the user would have to wait for no reason if they don't care about pending uploads

With this commit, we'll show a prompt before destructive operations that delete the VFS cache. If the user chooses to proceed, the deletion occurs immediately. This is not perfect though--a VFS writeback thread cannot be cancelled and will likely throw a checksum validation error when it completes.