### PR TITLE
Add support for automatically reloading CA certificates

### DIFF
--- a/UPDATES.md
+++ b/UPDATES.md
@@ -20,6 +20,10 @@ Hopefully, most issues can be found just by trying to compile rcbridge with `./g
 
 If librclone gained new functionality that can replace current uses of internal APIs, then that new functionality should be used. librclone RPC-related tasks should be done purely on the Android side in [`RcloneRpc`](./app/src/main/java/com/chiller3/rsaf/rclone/RcloneRpc.kt), not in go.
 
+### Certificate reloading
+
+Check if there's any way hook into `fshttp.(*Transport).RoundTrip()`. The hook to update `tls.Config.RootCAs` is the only reason we need to fork rclone.
+
 ### `RbDocMkdir`
 
 Check the `vfs.Dir.Mkdir()` implementation to see if it fails with EEXIST when the path already exists. If so, `RcloneProvider` can be updated to avoid an unnecessary stat when creating directories with Android semantics.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="pref_edit_remote_configure_name">Configure remote</string>
     <string name="pref_edit_remote_configure_desc">Rerun the rclone configuration wizard.</string>
     <string name="pref_edit_remote_rename_name">Rename remote</string>
-    <string name="pref_edit_remote_rename_desc">Change the name of the remote. If other remotes depends on this one, they will need to be manually updated with the new name.</string>
+    <string name="pref_edit_remote_rename_desc">Change the name of this remote. If other remotes depends on this one, they will need to be manually updated with the new name.</string>
     <string name="pref_edit_remote_duplicate_name">Duplicate remote</string>
     <string name="pref_edit_remote_duplicate_desc">Create a copy of this remote with identical configuration.</string>
     <string name="pref_edit_remote_delete_name">Delete remote</string>
@@ -93,7 +93,7 @@
 
     <!-- Edit remote alerts -->
     <string name="alert_edit_remote_success">Successfully edited remote %1$s</string>
-    <string name="alert_delete_remote_failure">Failed to delete %1$s: %2$s</string>
+    <string name="alert_delete_remote_failure">Failed to delete remote %1$s: %2$s</string>
     <string name="alert_rename_remote_failure">Failed to rename remote %1$s to %2$s: %3$s</string>
     <string name="alert_duplicate_remote_failure">Failed to duplicate remote %1$s to %2$s: %3$s</string>
     <string name="alert_set_config_failure">Failed to set %1$s config option for remote %2$s: %3$s</string>
@@ -127,7 +127,7 @@
     <string name="dialog_export_password_hint">Encryption password</string>
     <string name="dialog_inactivity_timeout_title">Inactivity timeout</string>
     <string name="dialog_inactivity_timeout_message">Enter a duration in seconds.</string>
-    <string name="dialog_vfs_cache_deletion_message">There are file operations in progress. These operations will be interrupted and pending uploads in the VFS cache will be permanently deleted.</string>
+    <string name="dialog_vfs_cache_deletion_message">There are pending uploads in progress that may be interrupted. These will be permanently deleted from the VFS cache.</string>
 
     <!-- Interactive configuration -->
     <string name="ic_title_add_remote">Add remote: %1$s</string>

--- a/rcbridge/go.mod
+++ b/rcbridge/go.mod
@@ -9,6 +9,8 @@ require (
 	golang.org/x/mobile v0.0.0-20250106192035-c31d5b91ecc3
 )
 
+replace github.com/rclone/rclone v1.69.0 => github.com/chenxiaolong/rclone v1.69.0-rsaf
+
 require (
 	cloud.google.com/go/auth v0.12.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.6 // indirect

--- a/rcbridge/go.sum
+++ b/rcbridge/go.sum
@@ -151,6 +151,8 @@ github.com/calebcase/tmpfile v1.0.3/go.mod h1:UAUc01aHeC+pudPagY/lWvt2qS9ZO5Zzof
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chenxiaolong/rclone v1.69.0-rsaf h1:URDbtwBv0+aKN2k7MkLCl1wxyxxKVSNy+it1t8JqL7A=
+github.com/chenxiaolong/rclone v1.69.0-rsaf/go.mod h1:RfT8WA1rU1/wHyujQ1r0MZFdO89zLSDgCuu62uImArg=
 github.com/chilts/sid v0.0.0-20190607042430-660e94789ec9 h1:z0uK8UQqjMVYzvk4tiiu3obv2B44+XBsvgEJREQfnO8=
 github.com/chilts/sid v0.0.0-20190607042430-660e94789ec9/go.mod h1:Jl2neWsQaDanWORdqZ4emBl50J4/aRBBS4FyyG9/PFo=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -467,8 +469,6 @@ github.com/quic-go/qtls-go1-20 v0.4.1 h1:D33340mCNDAIKBqXuAvexTNMUByrYmFYVfKfDN5
 github.com/quic-go/qtls-go1-20 v0.4.1/go.mod h1:X9Nh97ZL80Z+bX/gUXMbipO6OxdiDi58b/fMC9mAL+k=
 github.com/quic-go/quic-go v0.40.1 h1:X3AGzUNFs0jVuO3esAGnTfvdgvL4fq655WaOi1snv1Q=
 github.com/quic-go/quic-go v0.40.1/go.mod h1:PeN7kuVJ4xZbxSv/4OX6S1USOX8MJvydwpTx31vx60c=
-github.com/rclone/rclone v1.69.0 h1:fRfYu6Ha2Zn+nDLUa4ZuPXogddfeZG+jsCyhbOdAamw=
-github.com/rclone/rclone v1.69.0/go.mod h1:RfT8WA1rU1/wHyujQ1r0MZFdO89zLSDgCuu62uImArg=
 github.com/redis/go-redis/v9 v9.6.1 h1:HHDteefn6ZkTtY5fGUE8tj8uy85AHk6zP7CpzIAM0y4=
 github.com/redis/go-redis/v9 v9.6.1/go.mod h1:0C0c6ycQsdpVNQpxb1njEQIqkx5UcsM8FJCQLgE9+RA=
 github.com/relvacode/iso8601 v1.3.0 h1:HguUjsGpIMh/zsTczGN3DVJFxTU/GX+MMmzcKoMO7ko=


### PR DESCRIPTION
The initial implementation of loading Android's CA trust stores wrote the certificates to a temporary file and then passed them to rclone via the `CaCert` config option. This would only get loaded when a new backend `Fs` instance was created. If the backend was already created, the user would need to delete and recreate the remote or force quit RSAF, which is a terrible user experience.

Unfortunately, reloading by recreating the `Fs` and `VFS` instances would not provide a good experience either. The VFS would need to be shut down, interrupting VFS writeback, and we need to wait for the garbage collector to clean up the `VFS` instance so that the corresponding `Fs` instance would be unpinned from the cache. This precludes the CA reloading process from being automatic.

Instead, this commit makes use of a per-request hook to set the trusted CA certificates on every connection. This requires a soft-fork of rclone to add a hook point to `fshttp.(*Transport).RoundTrip()`. The patch is extremely simple and is easy to port to future versions of rclone. No other patches will be added to the fork and I plan to switch back to the upstream version if another good solution is found, even if hacky.

Some other approaches I tried or considered:

* Replace `fshttp.isCertificateExpired()` using `go:linkname` and in the replacement, update the `tls.Config.RootCAs` in addition to executing a copy of the original code. This function would be called during each `RoundTrip()` invocation. This approach does not work with how gomobile builds rcbridge as a library and causes duplicate symbol errors during linking.
* Add the code as is done in this commit, except via a `-toolexec` program that preprocesses the AST of the go sources. This approach does not work because `-toolexec` is not invoked at the necessary points when compiling with gomobile.
* Patch `fshttp.isCertificateExpired()` at runtime by inserting a jump call to our own implementation. This is error prone, requires specific assembly code for each CPU architecture, and does not work if the function we want to patch was inlined.

This commit also fixes a bug where a remote's `Fs` instance is not properly removed from rclone's cache when deleting the remote.

Issue: #119