### PR TITLE
Only allow copy/move via rclone when it can be done server-side

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteViewModel.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteViewModel.kt
@@ -8,8 +8,10 @@ package com.chiller3.rsaf.settings
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chiller3.rsaf.binding.rcbridge.RbError
 import com.chiller3.rsaf.binding.rcbridge.RbRemoteFeaturesResult
 import com.chiller3.rsaf.binding.rcbridge.Rcbridge
+import com.chiller3.rsaf.extension.toException
 import com.chiller3.rsaf.rclone.RcloneConfig
 import com.chiller3.rsaf.rclone.RcloneRpc
 import com.chiller3.rsaf.rclone.VfsCache
@@ -101,7 +103,11 @@ class EditRemoteViewModel : ViewModel() {
                 if (_remoteConfig.value.features == null) {
                     withContext(Dispatchers.IO) {
                         _remoteConfig.update {
-                            it.copy(features = Rcbridge.rbRemoteFeatures("$remote:"))
+                            val error = RbError()
+                            val features = Rcbridge.rbRemoteFeatures("$remote:", error)
+                                ?: throw error.toException("rbRemoteFeatures")
+
+                            it.copy(features = features)
                         }
                     }
                 }

--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -595,25 +595,30 @@ func getVfsForDoc(doc string) (*vfs.VFS, string, error) {
 }
 
 type RbRemoteFeaturesResult struct {
+	Copy      bool
+	Move      bool
 	PutStream bool
 	About     bool
 }
 
 // Return whether the specified remote supports streaming.
-func RbRemoteFeatures(remote string) (*RbRemoteFeaturesResult, error) {
+func RbRemoteFeatures(remote string, errOut *RbError) *RbRemoteFeaturesResult {
 	f, err := getFs(remote)
 	if err != nil {
-		return nil, err
+		assignError(errOut, err, syscall.EINVAL)
+		return nil
 	}
 
 	features := f.Features()
 
 	result := RbRemoteFeaturesResult{
+		Copy:      features.Copy != nil,
+		Move:      features.Move != nil,
 		PutStream: features.PutStream != nil,
 		About:     features.About != nil,
 	}
 
-	return &result, nil
+	return &result
 }
 
 type RbRemoteSplitResult struct {


### PR DESCRIPTION
If `copyDocument()` and `moveDocument()` are slow, the binder transaction will time out and Android will kill RSAF. If we can't perform the operation quickly via server-side operations, let's just tell the client that the operation is unsupported. Android's DocumentsUI specifically handles this scenario and will do the copy/move operation itself, which isn't subject to this problem.

Fixes: #124