### PR TITLE
Add debug option to add an alias remote for rclone's internal cache directory

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/Preferences.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Preferences.kt
@@ -36,8 +36,9 @@ class Preferences(private val context: Context) {
         const val PREF_EDIT_REMOTE_PREFIX = "edit_remote_"
         const val PREF_IMPORT_CONFIGURATION = "import_configuration"
         const val PREF_EXPORT_CONFIGURATION = "export_configuration"
-        const val PREF_SAVE_LOGS = "save_logs"
         const val PREF_VERSION = "version"
+        const val PREF_SAVE_LOGS = "save_logs"
+        const val PREF_ADD_INTERNAL_CACHE_REMOTE = "add_internal_cache_remote"
 
         // Edit remote UI actions
         const val PREF_OPEN_REMOTE = "open_remote"

--- a/app/src/main/java/com/chiller3/rsaf/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/SettingsFragment.kt
@@ -85,6 +85,7 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
     private lateinit var prefLockNow: Preference
     private lateinit var prefVersion: LongClickablePreference
     private lateinit var prefSaveLogs: Preference
+    private lateinit var prefAddInternalCacheRemote: Preference
 
     private val requestEditRemote =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
@@ -168,6 +169,9 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
 
         prefSaveLogs = findPreference(Preferences.PREF_SAVE_LOGS)!!
         prefSaveLogs.onPreferenceClickListener = this
+
+        prefAddInternalCacheRemote = findPreference(Preferences.PREF_ADD_INTERNAL_CACHE_REMOTE)!!
+        prefAddInternalCacheRemote.onPreferenceClickListener = this
 
         // Call this once first to avoid UI jank from elements shifting. We call it again in
         // onResume() because allowing the permissions does not restart the activity.
@@ -422,6 +426,10 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
             }
             preference === prefSaveLogs -> {
                 requestSafSaveLogs.launch(Logcat.FILENAME_DEFAULT)
+                return true
+            }
+            preference === prefAddInternalCacheRemote -> {
+                viewModel.addInternalCacheRemote()
                 return true
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,8 @@
     <string name="pref_verbose_rclone_logs_desc">Warning: The verbose logs may contain sensitive information, like authentication tokens.</string>
     <string name="pref_save_logs_name">Save logs</string>
     <string name="pref_save_logs_desc">Save logcat logs to a file. Note that the logs may contain names of remote files that have been accessed.</string>
+    <string name="pref_add_internal_cache_remote_name">Add rclone internal cache remote</string>
+    <string name="pref_add_internal_cache_remote_desc">Add a new <tt>alias</tt> remote that points to rclone\'s internal cache directory. This can be useful for troubleshooting VFS issues.</string>
 
     <!-- Remote preferences -->
     <string name="pref_edit_remote_open_name">Open remote</string>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -157,5 +157,12 @@
             app:title="@string/pref_save_logs_name"
             app:summary="@string/pref_save_logs_desc"
             app:iconSpaceReserved="false" />
+
+        <Preference
+            app:key="add_internal_cache_remote"
+            app:persistent="false"
+            app:title="@string/pref_add_internal_cache_remote_name"
+            app:summary="@string/pref_add_internal_cache_remote_desc"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This makes it easy to inspect rclone's `vfsMeta` directory, which contains JSON files describing the state of pending uploads.