### PR TITLE
gradle: Install local copy of gomobile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,6 @@ jobs:
           cache-dependency-path: rcbridge/go.sum
           go-version-file: rcbridge/go.mod
 
-      - name: Install gomobile
-        shell: bash
-        run: |-
-          version=$(grep golang.org/x/mobile rcbridge/go.mod | awk '{print $2}')
-          go install golang.org/x/mobile/cmd/gobind@"${version}"
-          go install golang.org/x/mobile/cmd/gomobile@"${version}"
-
       - name: Get NDK version
         id: get_version
         shell: bash

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ Before building, the following tools must be installed:
 * Android SDK
 * Android NDK
 * `go` (golang compiler)
-* `gomobile`
 
 Once the dependencies are installed, RSAF can be built like most other Android apps using Android Studio or the gradle command line.
 


### PR DESCRIPTION
Previously, we required the user to install gomobile and gobind system-wide. This was problematic because mismatched versions between the tools and the gomobile library can cause subtle errors, both at build time and at runtime.

This also helps with making the builds more reproducible.