### PR TITLE
Make gomobile shared library reproducible

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -332,6 +332,7 @@ val rcbridge = tasks.register("rcbridge") {
                 "-target=android",
                 "-androidapi=${android.defaultConfig.minSdk}",
                 "-javapkg=${android.namespace}.binding",
+                "-trimpath",
                 ".",
             )
             environment(


### PR DESCRIPTION
It included references to the build directory path before.