### PR TITLE
Add per-remote option for disabling thumbnails

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/Preferences.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Preferences.kt
@@ -49,6 +49,7 @@ class Preferences(private val context: Context) {
         const val PREF_ALLOW_EXTERNAL_ACCESS = "allow_external_access"
         const val PREF_ALLOW_LOCKED_ACCESS = "allow_locked_access"
         const val PREF_DYNAMIC_SHORTCUT = "dynamic_shortcut"
+        const val PREF_THUMBNAILS = "thumbnails"
         const val PREF_VFS_CACHING = "vfs_caching"
         const val PREF_REPORT_USAGE = "report_usage"
 

--- a/app/src/main/java/com/chiller3/rsaf/rclone/VfsCache.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/VfsCache.kt
@@ -113,10 +113,10 @@ object VfsCache {
 
         Log.d(TAG, "Initializing VFS for remotes: $neededRemotes")
 
-        for ((remote, config) in RcloneRpc.remotes) {
+        for ((remote, config) in RcloneRpc.remoteConfigs) {
             if (!neededRemotes.remove(remote)) {
                 continue
-            } else if (!RcloneRpc.getCustomBoolOpt(config, RcloneRpc.CUSTOM_OPT_VFS_CACHING)) {
+            } else if (!config.vfsCachingOrDefault) {
                 // The user will have to re-enable VFS caching to upload these.
                 continue
             }

--- a/app/src/main/java/com/chiller3/rsaf/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/SettingsViewModel.kt
@@ -24,7 +24,6 @@ import java.io.File
 
 data class Remote(
     val name: String,
-    val config: Map<String, String>,
     val provider: RcloneRpc.Provider?,
 )
 
@@ -77,8 +76,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             val r = withContext(Dispatchers.IO) {
                 val providers = RcloneRpc.providers
 
-                RcloneRpc.remotes.map {
-                    Remote(it.key, it.value, providers[it.value["type"]])
+                RcloneRpc.remoteConfigsRaw.map {
+                    Remote(it.key, providers[it.value["type"]])
                 }.sortedBy { it.name }
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
     <string name="pref_edit_remote_allow_locked_access_desc_off">While RSAF is locked, files are hidden from external apps and new file operations are blocked. Ongoing operations with files that are already open are unaffected.</string>
     <string name="pref_edit_remote_dynamic_shortcut_name">Show in launcher shortcuts</string>
     <string name="pref_edit_remote_dynamic_shortcut_desc">Include this remote in the list of shortcuts when long pressing RSAF\'s launcher icon.</string>
+    <string name="pref_edit_remote_thumbnails_name">Enable thumbnails</string>
+    <string name="pref_edit_remote_thumbnails_desc">Allow showing thumbnails for images, videos, and music (album art). This may result in additional network traffic when browsing files.</string>
     <string name="pref_edit_remote_vfs_caching_name">Enable VFS caching</string>
     <string name="pref_edit_remote_vfs_caching_desc_loading">(Checking if streaming is supported…)</string>
     <string name="pref_edit_remote_vfs_caching_desc_optional">VFS caching enables support for random writes and allows failed uploads to be retried. However, files do not begin uploading until the client app closes them.</string>

--- a/app/src/main/res/xml/preferences_edit_remote.xml
+++ b/app/src/main/res/xml/preferences_edit_remote.xml
@@ -1,5 +1,5 @@
 <!--
-    SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
@@ -70,6 +70,14 @@
             app:title="@string/pref_edit_remote_dynamic_shortcut_name"
             app:summary="@string/pref_edit_remote_dynamic_shortcut_desc"
             app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            app:key="thumbnails"
+            app:persistent="false"
+            app:title="@string/pref_edit_remote_thumbnails_name"
+            app:summary="@string/pref_edit_remote_thumbnails_desc"
+            app:iconSpaceReserved="false"
+            app:defaultValue="true" />
 
         <SwitchPreferenceCompat
             app:key="vfs_caching"


### PR DESCRIPTION
This can cause a significant amount of traffic, especially when scrolling in DocumentsUI. It might be enough to hit rate limits with some providers.

This commit also refactors the custom options mechanism to use an intermediate data object instead of dealing with raw config values everywhere.

Issue: #155