### PR TITLE
rcbridge/go.mod: Remove toolchain version

### DIFF
--- a/rcbridge/go.mod
+++ b/rcbridge/go.mod
@@ -2,8 +2,6 @@ module rcbridge
 
 go 1.24.0
 
-toolchain go1.24.1
-
 require (
 	github.com/rclone/rclone v1.71.0
 	golang.org/x/mobile v0.0.0-20250813145510-f12310a0cfd9


### PR DESCRIPTION
Specifying a specific toolchain version was not intended, only a minimum version.

Issue: #50