### PR TITLE
Remove Google Play dependency info block

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -193,6 +193,10 @@ android {
             include("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
         }
     }
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
 }
 
 kotlin {


### PR DESCRIPTION
This metadata is encrypted with Google's public key and is unreadable by anyone else. We have no need for this.

Issue: #50