### PR TITLE
interactive_configuration: Make message text selectable

### DIFF
--- a/app/src/main/res/layout/dialog_interactive_configuration.xml
+++ b/app/src/main/res/layout/dialog_interactive_configuration.xml
@@ -19,7 +19,8 @@
             android:id="@+id/message"
             style="?attr/materialAlertDialogBodyTextStyle"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:textIsSelectable="true" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/text_layout"


### PR DESCRIPTION
Provider questions can sometimes contain commands that the user would want to copy.

Fixes: #193