### PR TITLE
rcbridge: Call fs.LogReload when changing log level

### DIFF
--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -288,6 +288,8 @@ func RbSetLogVerbosity(verbosity int) {
 	} else {
 		ci.LogLevel = fs.LogLevelNotice
 	}
+
+	fs.LogReload(ci)
 }
 
 type RbRpcResult struct {


### PR DESCRIPTION
Without this, debug logs never show up because nothing will set slog's maximum log level.

The behavior changed in upstream version 1.70.0 when they replaced logrus with slog in commit dfa4d948279f3e36a8256542808707a29fd416e0.