### PR TITLE
Update dynamic shortcuts whenever SAF roots are changed

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteViewModel.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteViewModel.kt
@@ -142,7 +142,9 @@ class EditRemoteViewModel : ViewModel() {
     }
 
     fun setDynamicShortcut(enabled: Boolean) {
-        setCustomOpt(remote, RcloneRpc.RemoteConfig(dynamicShortcut = enabled))
+        setCustomOpt(remote, RcloneRpc.RemoteConfig(dynamicShortcut = enabled)) {
+            _activityActions.update { it.copy(refreshRoots = true) }
+        }
     }
 
     fun setThumbnails(enabled: Boolean) {

--- a/app/src/main/java/com/chiller3/rsaf/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/SettingsFragment.kt
@@ -11,7 +11,6 @@ import android.os.Bundle
 import android.os.Environment
 import android.provider.DocumentsContract
 import android.provider.Settings
-import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentResultListener
@@ -262,8 +261,7 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.activityActions.collect {
                     if (it.refreshRoots) {
-                        Log.d(TAG, "Notifying system of new SAF roots")
-                        RcloneProvider.notifyRootsChanged(requireContext().contentResolver)
+                        RcloneProvider.notifyRootsChanged(requireContext())
                     }
                     viewModel.activityActionCompleted()
                 }


### PR DESCRIPTION
Previously, shortcuts didn't get updated when importing an rclone config. Let's just merge the SAF roots notification and dynamic shortcut update operations so they're always in sync.