### PR TITLE
Enable proguard obfuscation

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,15 +11,3 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
--keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
-
-# Disable obfuscation completely for RSAF. As an open source project,
-# shrinking is the only goal of minification.
--dontobfuscate


### PR DESCRIPTION
Previously, this was disabled because the app is open source and there is no need to mask information in stack traces. However, optimizations in recent r8 versions make the stack traces quite useless anyway, even without obfuscation. Given that, let's switch back to the default behavior so that at least we can take advantage of smaller APK sizes.

The mapping files will be published alongside official releases so that anyone can decode stacktraces from logs without needing a debug build.