### PR TITLE
Ensure output files are truncated

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/Logcat.kt
+++ b/app/src/main/java/com/chiller3/rsaf/Logcat.kt
@@ -51,7 +51,7 @@ object Logcat {
 
             Log.d(TAG, "Moving $tempFile to $uri")
 
-            val out = applicationContext.contentResolver.openOutputStream(uri)
+            val out = applicationContext.contentResolver.openOutputStream(uri, "wt")
                 ?: throw IOException("Failed to open URI: $uri")
             out.use { outStream ->
                 tempFile.inputStream().use { inStream ->

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneConfig.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneConfig.kt
@@ -192,7 +192,7 @@ object RcloneConfig {
     }
 
     fun exportConfigurationUri(uri: Uri, password: String) {
-        val output = applicationContext.contentResolver.openOutputStream(uri)
+        val output = applicationContext.contentResolver.openOutputStream(uri, "wt")
             ?: throw IOException("Failed to open for writing: $uri")
 
         output.use {


### PR DESCRIPTION
Otherwise, this leads to not-easily-fixable corruption, especially with encrypted rclone configs where it's not obvious where the data ends.