### PR TITLE
Add support for EEXIST for files when VFS caching is disabled

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
@@ -800,23 +800,9 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
         val base = Rcbridge.rbPathJoin(parentDocumentId, baseName)
         val error = RbError()
 
-        // We can skip the stat and avoid TOCTOU when creating files because it properly fails with
-        // EEXIST. Unfortunately, this is not the case with mkdir.
-        val method = if (isDir) {
-            ConflictDetection.STAT
-        } else {
-            ConflictDetection.EEXIST
-        }
-
-        return retryUnique(base, ext, method) {
+        return retryUnique(base, ext, ConflictDetection.EEXIST) {
             if (isDir) {
                 if (!Rcbridge.rbDocMkdir(it, DIRECTORY_PERMS.toLong(), error)) {
-                    // This is unfortunately racy, but we need to use a different error code than
-                    // EEXIST when the user tries to create a directory on top of a file
-                    if (!documentIsDir(it)) {
-                        error.code = OsConstants.ENOTDIR.toLong()
-                    }
-
                     throw error.toException("rbDocMkdir")
                 }
             } else {

--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -1007,6 +1007,22 @@ func RbDocMkdir(doc string, perms int, errOut *RbError) bool {
 		return false
 	}
 
+	// rclone does not ever return EEXIST, so we'll have to simulate it
+	// ourselves, sadly with TOCTOU.
+	fi, err := v.Stat(path)
+	if err != nil {
+		if err != vfs.ENOENT {
+			assignError(errOut, err, syscall.EIO)
+			return false
+		}
+	} else if fi.Mode().IsRegular() {
+		assignError(errOut, fs.ErrorIsFile, syscall.ENOTDIR)
+		return false
+	} else {
+		assignError(errOut, vfs.EEXIST, syscall.EEXIST)
+		return false
+	}
+
 	err = v.Mkdir(path, ioFs.FileMode(perms&int(ioFs.ModePerm)))
 	if err != nil {
 		assignError(errOut, err, syscall.EIO)
@@ -1168,9 +1184,30 @@ func RbDocOpen(doc string, flags int, mode int, errOut *RbError) *RbFile {
 		return nil
 	}
 
-	if v.Opt.CacheMode < vfscommon.CacheModeWrites && flags&(os.O_WRONLY|os.O_RDWR) != 0 {
-		fs.Logf(nil, "Forcing O_TRUNC for writable file due to streaming")
-		flags |= os.O_TRUNC
+	if v.Opt.CacheMode < vfscommon.CacheModeWrites {
+		if flags&(os.O_WRONLY|os.O_RDWR) != 0 {
+			fs.Logf(nil, "Forcing O_TRUNC for writable file due to streaming")
+			flags |= os.O_TRUNC
+		}
+
+		// rclone only properly returns EEXIST when newRWFileHandle() is called,
+		// but that only happens via openRW() when caching is enabled, not with
+		// openWrite().
+		if flags&os.O_CREATE != 0 && flags&os.O_EXCL != 0 {
+			fi, err := v.Stat(path)
+			if err != nil {
+				if err != vfs.ENOENT {
+					assignError(errOut, err, syscall.EIO)
+					return nil
+				}
+			} else if fi.Mode().IsDir() {
+				assignError(errOut, fs.ErrorIsDir, syscall.EISDIR)
+				return nil
+			} else {
+				assignError(errOut, vfs.EEXIST, syscall.EEXIST)
+				return nil
+			}
+		}
 	}
 
 	handle, err := v.OpenFile(path, flags, ioFs.FileMode(mode&int(ioFs.ModePerm)))


### PR DESCRIPTION
rclone only returns `EEXIST` for regular files when VFS caching is enabled. When VFS caching is disabled, opening with `O_CREAT|O_EXCL` always succeeds, breaking the file conflict detection and causing existing files to be overwritten.

This commit also moves the `ENOTDIR` and `EEXIST` handling for directories into `RbDocMkdir()`.