### PR TITLE
gradle: Ensure forked golang is always used

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -293,6 +293,7 @@ val goenv = tasks.register("goenv") {
     val envVars = arrayOf(
         "GOPROXY",
         "GOSUMDB",
+        "GOTOOLCHAIN",
         "GOFLAGS",
     ).associateWith { System.getenv(it) }
     val goModFile = File(rcbridgeSrcDir, "go.mod")
@@ -309,6 +310,7 @@ val goenv = tasks.register("goenv") {
             // https://src.fedoraproject.org/rpms/golang/c/1a696ebca1b2d5227921924d3f9885e18cf445b5
             "GOPROXY" to "https://proxy.golang.org,direct",
             "GOSUMDB" to "sum.golang.org",
+            "GOTOOLCHAIN" to "local",
             "GOFLAGS" to "-ldflags=-buildid= -buildvcs=false",
         )
 


### PR DESCRIPTION
Without this, a newer host toolchain could be used instead.