### PR TITLE
Ignore app lock when device has no lock screen configured

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/PreferenceBaseActivity.kt
+++ b/app/src/main/java/com/chiller3/rsaf/PreferenceBaseActivity.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -52,8 +52,8 @@ abstract class PreferenceBaseActivity : AppCompatActivity() {
             } else {
                 // We can't know the reason.
                 onAuthenticationError(
-                    BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL,
-                    getString(R.string.biometric_error_no_device_credential),
+                    BiometricPrompt.ERROR_USER_CANCELED,
+                    getString(R.string.biometric_error_cancelled),
                 )
             }
         }
@@ -235,9 +235,9 @@ abstract class PreferenceBaseActivity : AppCompatActivity() {
     private fun startLegacyDeviceCredentialAuth() {
         Log.d(tag, "Starting legacy device credential authentication")
 
-        val keyGuardManager = getSystemService(KeyguardManager::class.java)
+        val keyguardManager = getSystemService(KeyguardManager::class.java)
         @Suppress("DEPRECATION")
-        val intent = keyGuardManager?.createConfirmDeviceCredentialIntent(
+        val intent = keyguardManager?.createConfirmDeviceCredentialIntent(
             getString(R.string.biometric_title),
             "",
         )
@@ -247,13 +247,23 @@ abstract class PreferenceBaseActivity : AppCompatActivity() {
         } else {
             onAuthenticationError(
                 BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL,
-                getString(R.string.biometric_error_no_device_credential),
+                getString(R.string.biometric_ignore),
             )
         }
     }
 
     fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
         Log.d(tag, "Authentication error: $errorCode: $errString")
+
+        if (errorCode == BiometricPrompt.ERROR_NO_BIOMETRICS
+                || errorCode == BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL) {
+            Log.w(tag, "No biometrics or device credential; allowing access")
+
+            Toast.makeText(this, R.string.biometric_ignore, Toast.LENGTH_LONG).show()
+
+            onAuthenticationSucceeded()
+            return
+        }
 
         Toast.makeText(
             this,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,7 +107,8 @@
     <!-- Biometric -->
     <string name="biometric_title">Unlock configuration</string>
     <string name="biometric_error">Biometric authentication error: %1$s</string>
-    <string name="biometric_error_no_device_credential">No device credential</string>
+    <string name="biometric_error_cancelled">Unlock operation cancelled</string>
+    <string name="biometric_ignore">Ignoring app lock because device has no screen lock configured</string>
 
     <!-- Dialogs -->
     <string name="dialog_action_next">Next</string>


### PR DESCRIPTION
Otherwise, the user is just locked out of the app until they enable a screen lock and turn the app lock option back off.