### PR TITLE
RcloneRpc: Avoid resetting all custom options when setting single option

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/dialog/VfsOptionsDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/dialog/VfsOptionsDialogFragment.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2025-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -48,13 +48,11 @@ class VfsOptionsDialogFragment : DialogFragment() {
 
     private lateinit var binding: DialogVfsOptionsBinding
     private lateinit var remote: String
-    private lateinit var config: RcloneRpc.RemoteConfig
     private var overrides: Map<String, String>? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val arguments = requireArguments()
         remote = arguments.getString(ARG_REMOTE)!!
-        config = RcloneRpc.remoteConfigs[remote]!!
 
         binding = DialogVfsOptionsBinding.inflate(layoutInflater)
 
@@ -101,6 +99,8 @@ class VfsOptionsDialogFragment : DialogFragment() {
         }
 
         if (savedInstanceState == null) {
+            val config = RcloneRpc.remoteConfigs[remote]!!
+
             binding.text.setText(buildString {
                 for ((key, value) in config.vfsOptions) {
                     if (isNotEmpty()) {
@@ -196,7 +196,7 @@ class VfsOptionsDialogFragment : DialogFragment() {
     }
 
     private fun save(reload: Boolean) {
-        RcloneRpc.setRemoteConfig(remote, config.copy(vfsOptions = overrides!!))
+        RcloneRpc.setRemoteConfig(remote, RcloneRpc.RemoteConfig(vfsOptions = overrides!!))
 
         if (reload) {
             Rcbridge.rbCacheClearRemote("$remote:", false)

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneRpc.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneRpc.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -26,6 +26,15 @@ object RcloneRpc {
     private const val DEFAULT_DYNAMIC_SHORTCUT = false
     private const val DEFAULT_THUMBNAILS = true
     private const val DEFAULT_REPORT_USAGE = false
+
+    private fun isKnownKey(key: String) =
+        !key.startsWith(CUSTOM_OPT_PREFIX)
+                || key == CUSTOM_OPT_HARD_BLOCKED
+                || key == CUSTOM_OPT_SOFT_BLOCKED
+                || key == CUSTOM_OPT_DYNAMIC_SHORTCUT
+                || key == CUSTOM_OPT_THUMBNAILS
+                || key == CUSTOM_OPT_REPORT_USAGE
+                || key.startsWith(CUSTOM_OPT_VFS_OPTIONS_PREFIX)
 
     /**
      * Perform an rclone RPC call.
@@ -452,12 +461,12 @@ object RcloneRpc {
     }
 
     fun setRemoteConfig(remote: String, config: RemoteConfig) {
-        // Ensure we don't leave behind legacy options.
         val updates = mutableMapOf<String, String?>()
 
+        // Ensure we don't leave behind legacy options.
         remoteConfigsRaw[remote]
             ?.asSequence()
-            ?.filter { (key, _) -> key.startsWith(CUSTOM_OPT_PREFIX) }
+            ?.filter { (key, _) -> !isKnownKey(key) }
             ?.associateTo(updates) { (key, _) -> key to null }
 
         updates.putAll(config.toMap())


### PR DESCRIPTION
The intention was to automatically remove all legacy custom options when setting any new custom option. However, the incorrect conditional caused all custom options to be reset to their defaults when changing a single one. This was a regression introduced in commit 42e18b38d1cb67cdb0302220f331850eb373d6d4.

Fixes: #258