### PR TITLE
InteractiveConfiguration: Add support for going back

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -188,6 +188,11 @@ android {
             include(*abis)
         }
     }
+    lint {
+        // The translations are always going to lag behind new strings being
+        // added to values/strings.xml
+        disable += "MissingTranslation"
+    }
     dependenciesInfo {
         includeInApk = false
         includeInBundle = false

--- a/app/src/main/java/com/chiller3/rsaf/dialog/InteractiveConfigurationDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/rsaf/dialog/InteractiveConfigurationDialogFragment.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -85,7 +85,6 @@ class InteractiveConfigurationDialogFragment : DialogFragment() {
     private var currentOrDefault = ""
     private var userInput = ""
     private var lastOptionName: String? = null
-    private var neutralIsAuthorize = false
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val arguments = requireArguments()
@@ -118,6 +117,15 @@ class InteractiveConfigurationDialogFragment : DialogFragment() {
             }
         }
 
+        binding.authorize.setOnClickListener {
+            val cmd = viewModel.question.value!!.second.authorizeCmd
+
+            AuthorizeDialogFragment.newInstance(cmd).show(
+                parentFragmentManager.beginTransaction(),
+                AuthorizeDialogFragment.TAG,
+            )
+        }
+
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 viewModel.run.collect {
@@ -145,7 +153,7 @@ class InteractiveConfigurationDialogFragment : DialogFragment() {
             .setView(binding.root)
             .setPositiveButton(R.string.dialog_action_next, null)
             .setNegativeButton(android.R.string.cancel, null)
-            .setNeutralButton("placeholder", null)
+            .setNeutralButton(R.string.dialog_action_back, null)
             .create()
             .apply {
                 if (Preferences(requireContext()).dialogsAtBottom) {
@@ -169,17 +177,13 @@ class InteractiveConfigurationDialogFragment : DialogFragment() {
                     getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener {
                         dismiss()
                     }
+                    getButton(AlertDialog.BUTTON_NEGATIVE).setOnLongClickListener {
+                        userInput = currentOrDefault
+                        setStateFromInput()
+                        true
+                    }
                     getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
-                        if (neutralIsAuthorize) {
-                            val cmd = viewModel.question.value!!.second.authorizeCmd
-
-                            AuthorizeDialogFragment.newInstance(cmd)
-                                .show(parentFragmentManager.beginTransaction(),
-                                    AuthorizeDialogFragment.TAG)
-                        } else {
-                            userInput = currentOrDefault
-                            setStateFromInput()
-                        }
+                        viewModel.goBack()
                     }
                 }
             }
@@ -198,7 +202,7 @@ class InteractiveConfigurationDialogFragment : DialogFragment() {
                     updateMessage(error, option)
                     updateInput(option)
                     updateExamples(option)
-                    updateNeutralButton(option)
+                    updateAuthorize(option)
 
                     if (lastOptionName != option.name) {
                         userInput = currentOrDefault
@@ -208,6 +212,14 @@ class InteractiveConfigurationDialogFragment : DialogFragment() {
                     setStateFromInput()
 
                     lastOptionName = option.name
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.hasPrevious.collect { hasPrevious ->
+                    dialog.getButton(AlertDialog.BUTTON_NEUTRAL).isEnabled = hasPrevious
                 }
             }
         }
@@ -363,17 +375,8 @@ class InteractiveConfigurationDialogFragment : DialogFragment() {
         }
     }
 
-    private fun updateNeutralButton(option: RcloneRpc.ProviderOption) {
-        val dialog = dialog as AlertDialog
-        val button = dialog.getButton(AlertDialog.BUTTON_NEUTRAL)
-
-        neutralIsAuthorize = option.isAuthorize
-
-        button.setText(if (option.isAuthorize) {
-            R.string.dialog_action_authorize
-        } else {
-            R.string.dialog_action_reset
-        })
+    private fun updateAuthorize(option: RcloneRpc.ProviderOption) {
+        binding.authorize.isVisible = option.isAuthorize
     }
 
     /**
@@ -386,9 +389,6 @@ class InteractiveConfigurationDialogFragment : DialogFragment() {
 
         val dialog = dialog as AlertDialog
         dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = ok
-
-        dialog.getButton(AlertDialog.BUTTON_NEUTRAL).isEnabled =
-            neutralIsAuthorize || userInput != currentOrDefault
     }
 
     /**

--- a/app/src/main/java/com/chiller3/rsaf/dialog/InteractiveConfigurationViewModel.kt
+++ b/app/src/main/java/com/chiller3/rsaf/dialog/InteractiveConfigurationViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -10,7 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.chiller3.rsaf.rclone.RcloneRpc
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -19,17 +19,21 @@ class InteractiveConfigurationViewModel : ViewModel() {
     private lateinit var ic: RcloneRpc.InteractiveConfiguration
 
     private val _question = MutableStateFlow<Pair<String?, RcloneRpc.ProviderOption>?>(null)
-    val question: StateFlow<Pair<String?, RcloneRpc.ProviderOption>?> = _question
+    val question = _question.asStateFlow()
+
+    private val _hasPrevious = MutableStateFlow(false)
+    val hasPrevious = _hasPrevious.asStateFlow()
 
     private val _run = MutableStateFlow(true)
-    val run: StateFlow<Boolean> = _run
+    val run = _run.asStateFlow()
 
     fun init(remote: String) {
         viewModelScope.launch {
             ic = withContext(Dispatchers.IO) {
                 RcloneRpc.InteractiveConfiguration(remote)
             }
-            _question.update { ic.question }
+
+            loadQuestion()
         }
     }
 
@@ -38,11 +42,25 @@ class InteractiveConfigurationViewModel : ViewModel() {
             withContext(Dispatchers.IO) {
                 ic.submit(result)
             }
-            _question.update { ic.question }
 
-            if (ic.question == null) {
-                _run.update { false }
-            }
+            loadQuestion()
         }
+    }
+
+    private fun loadQuestion() {
+        val question = ic.question
+
+        _question.update { question }
+        _hasPrevious.update { ic.hasPrevious }
+
+        if (question == null) {
+            _run.update { false }
+        }
+    }
+
+    fun goBack() {
+        ic.goBack()
+
+        loadQuestion()
     }
 }

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneRpc.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneRpc.kt
@@ -298,15 +298,26 @@ object RcloneRpc {
     }
 
     class InteractiveConfiguration(private val remote: String) {
-        private var create = remote !in remoteNames
-        private var state: String? = null
+        companion object {
+            private val SKIP_QUESTIONS = mapOf(
+                // We require either using Authorizer or having the user manually run rclone
+                // authorize. If true is selected, the question prints to stdout and blocks until
+                // the authorization is complete.
+                "config_is_local" to "false",
+            )
+        }
+
+        private var states = mutableListOf<String?>()
+        // answers[i] is for states[i - 1].
+        private var answers = mutableListOf<String?>()
         private var error: String? = null
-        private var option: ProviderOption? = if (create) { providerQuestion } else { null }
+        private var option = if (remote !in remoteNames) { providerQuestion } else { null }
+        private var skipped = 0
 
         init {
             // If we're not creating a new remote, we need to start the config process to get the
             // first question
-            if (!create) {
+            if (option == null) {
                 submit(null)
             }
         }
@@ -322,7 +333,18 @@ object RcloneRpc {
         val question: Pair<String?, ProviderOption>?
             get() = option?.let { Pair(error, it) }
 
-        fun submit(answer: String?) {
+        /**
+         * Whether it's possible to go back to a previous question.
+         *
+         * It is not possible to go back to the remote type question because once submitted, the
+         * remote will have already been created.
+         */
+        val hasPrevious: Boolean
+            get() = states.size + skipped >= 2
+
+        private fun submitRaw(answer: String?) {
+            val isProviderQuestion = option === providerQuestion
+
             val input = JSONObject()
                 .put("name", remote)
                 // The parameters field is required to exist even in interactive mode.
@@ -332,10 +354,10 @@ object RcloneRpc {
                     .put("all", true)
                     .put("obscure", true)
                     .apply {
-                        state?.let {
+                        states.lastOrNull()?.let {
                             put("state", it)
                         }
-                        if (!create) {
+                        if (!isProviderQuestion) {
                             val result = answer?.let {
                                 // The "obscure" flag is currently ignored for the "result" value:
                                 // https://github.com/rclone/rclone/issues/7069
@@ -352,32 +374,86 @@ object RcloneRpc {
                     }
                 )
                 .apply {
-                    if (create) {
+                    if (isProviderQuestion) {
                         put("type", answer)
                     }
                 }
 
-            val method = if (create) {
+            val method = if (isProviderQuestion) {
                 "config/create"
             } else {
                 "config/update"
             }
 
             val output = invoke(method, input)
-            create = false
 
-            state = output.getString("State")
+            if (output.has("Error")) {
+                error = output.getString("Error")
+            }
+
+            // We intentionally can't go back to the provider question because the remote will have
+            // been created at this point. Clear out the answer before persisting so that the state
+            // is just like if we were freshly editing an existing remote.
+            val savedAnswer = if (isProviderQuestion) {
+                null
+            } else {
+                answer
+            }
+
+            val state = output.getString("State")
+            if (state != states.lastOrNull()) {
+                // Avoid duplicates when retrying.
+                states.add(state)
+                answers.add(savedAnswer)
+            } else {
+                answers[answers.size - 1] = savedAnswer
+            }
+
             option = if (output.isNull("Option")) {
                 null
             } else {
                 ProviderOption(output.getJSONObject("Option"))
             }
+        }
 
-            // We require either using Authorizer or having the user manually run rclone authorize.
-            // If true is selected, the question prints to stdout and blocks until the authorization
-            // is complete.
-            if (option?.name == "config_is_local") {
-                submit("false")
+        fun submit(answer: String?) {
+            submitRaw(answer)
+
+            while (true) {
+                val name = option?.name ?: break
+                val skipAnswer = SKIP_QUESTIONS[name] ?: break
+
+                submitRaw(skipAnswer)
+                skipped += 1
+            }
+        }
+
+        private fun goBackRaw(): String? {
+            // When displaying question C:
+            //   states:        [A, B, C]
+            //   answers: [null, A, B]
+            //   submit:               C
+            // to query question B, we need to resubmit with state A and answer A:
+            //   states:        [A]
+            //   answers: [null]
+            //   submit:         A
+            states.removeAt(states.lastIndex)
+            states.removeAt(states.lastIndex)
+            answers.removeAt(answers.lastIndex)
+            return answers.removeAt(answers.lastIndex)
+        }
+
+        fun goBack() {
+            if (!hasPrevious) {
+                throw IllegalStateException("No previous state")
+            }
+
+            submitRaw(goBackRaw())
+
+            while (option?.name in SKIP_QUESTIONS) {
+                val previousAnswer = goBackRaw()
+                skipped -= 1
+                submitRaw(previousAnswer)
             }
         }
     }

--- a/app/src/main/res/layout/dialog_interactive_configuration.xml
+++ b/app/src/main/res/layout/dialog_interactive_configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
@@ -49,6 +49,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/abc_dialog_title_divider_material"
+            android:visibility="gone" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/authorize"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/abc_dialog_title_divider_material"
+            android:layout_gravity="center_horizontal"
+            android:text="@string/dialog_action_authorize"
             android:visibility="gone" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -113,7 +113,6 @@
     <!-- Dialogs -->
     <string name="dialog_action_next">下一步</string>
     <string name="dialog_action_authorize">授权</string>
-    <string name="dialog_action_reset">重置</string>
     <string name="dialog_action_proceed_anyway">继续进行</string>
     <string name="dialog_remote_name_message">为远程存储输入名称。</string>
     <string name="dialog_remote_name_hint">远程存储名称</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-    SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <resources>
@@ -111,9 +111,9 @@
     <string name="biometric_ignore">Ignoring app lock because device has no screen lock configured</string>
 
     <!-- Dialogs -->
+    <string name="dialog_action_back">Back</string>
     <string name="dialog_action_next">Next</string>
     <string name="dialog_action_authorize">Authorize</string>
-    <string name="dialog_action_reset">Reset</string>
     <string name="dialog_action_proceed_anyway">Proceed anyway</string>
     <string name="dialog_remote_name_message">Enter a name for the remote.</string>
     <string name="dialog_remote_name_hint">Remote name</string>


### PR DESCRIPTION
This is done by caching rclone's state for all previous questions and the answers submitted for them. Going backwards requires resubmitting the answer to the question before the previous question. For now, this works fine because rclone's state string is reusable. If that ever changes, we'll need to do an O(n) resubmission of every prior queestion each time the user tries to go back.

Closes: #284