### PR TITLE
rcbridge: Replace CA certs at the crypto/x509 layer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -500,6 +500,15 @@ val rcbridge = tasks.register("rcbridge") {
         val binDir = gomobileExecutable.parentFile
 
         injected.execOps.exec {
+            val ldflags = arrayOf(
+                // Needed for working around golang's deficient CA certificate handling on Android.
+                "-checklinkname=0",
+                // We need to repeat the ldflags from the goenv task. There is currently no way to
+                // extend the existing value provided via an environment variable.
+                // https://github.com/golang/go/issues/38522
+                "-buildid=",
+            )
+
             executable(gomobileExecutable)
             args(
                 "bind",
@@ -509,6 +518,7 @@ val rcbridge = tasks.register("rcbridge") {
                 "-androidapi=${android.defaultConfig.minSdk}",
                 "-javapkg=${android.namespace}.binding",
                 "-trimpath",
+                "-ldflags=${ldflags.joinToString(" ")}",
                 ".",
             )
             environment(

--- a/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/RcloneProvider.kt
@@ -448,7 +448,6 @@ class RcloneProvider : DocumentsProvider(), SharedPreferences.OnSharedPreference
         Os.setenv("XDG_CACHE_HOME", context.cacheDir.path, true)
 
         Rcbridge.rbInit()
-        Rcbridge.rbReloadCerts()
         RcloneConfig.init(context)
         VfsCache.init(context)
         updateRcloneVerbosity()

--- a/rcbridge/go.mod
+++ b/rcbridge/go.mod
@@ -7,8 +7,6 @@ require (
 	golang.org/x/mobile v0.0.0-20260520154334-0e4426e1883d
 )
 
-replace github.com/rclone/rclone v1.74.2 => github.com/chenxiaolong/rclone v1.74.2-rsaf.0
-
 // https://github.com/chenxiaolong/RSAF/issues/268
 // https://github.com/t3rm1n4l/go-mega/pull/61
 replace github.com/t3rm1n4l/go-mega v0.0.0-20251031123324-a804aaa87491 => github.com/chenxiaolong/go-mega v0.0.0-20260412203312-607e36c7f6ca

--- a/rcbridge/go.sum
+++ b/rcbridge/go.sum
@@ -167,8 +167,6 @@ github.com/calebcase/tmpfile v1.0.3/go.mod h1:UAUc01aHeC+pudPagY/lWvt2qS9ZO5Zzof
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chenxiaolong/rclone v1.74.2-rsaf.0 h1:lDQif/2gAoT/sv1YnjFqUZ+LLTORd2XcCwvi2gF2PXY=
-github.com/chenxiaolong/rclone v1.74.2-rsaf.0/go.mod h1:qPZj+8uJBJEwNonEovOyGqSHgM9AdiQr1S7JGlALhNc=
 github.com/chilts/sid v0.0.0-20190607042430-660e94789ec9 h1:z0uK8UQqjMVYzvk4tiiu3obv2B44+XBsvgEJREQfnO8=
 github.com/chilts/sid v0.0.0-20190607042430-660e94789ec9/go.mod h1:Jl2neWsQaDanWORdqZ4emBl50J4/aRBBS4FyyG9/PFo=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -518,6 +516,8 @@ github.com/rclone/Proton-API-Bridge v1.0.3 h1:Bs7RC4xCFSN0BPIYVda/BNxp0qo3NV0gB2
 github.com/rclone/Proton-API-Bridge v1.0.3/go.mod h1:26RAest751Ofk+F/d8xtl4UyWXrZvMQwn39U8rm/WKM=
 github.com/rclone/go-proton-api v1.0.2 h1:cJtJUab0MGJ3C6q5kiEJs3pbyhSLnOKMyYOQehA0PBc=
 github.com/rclone/go-proton-api v1.0.2/go.mod h1:LB2kCEaZMzNn3ocdz+qYfxXmuLxxN0ka62KJd2x53Bc=
+github.com/rclone/rclone v1.74.2 h1:+dpmKO46pt1RYRN+/xOE5uXsPU5V3azyjdHOEpXq0Mo=
+github.com/rclone/rclone v1.74.2/go.mod h1:qPZj+8uJBJEwNonEovOyGqSHgM9AdiQr1S7JGlALhNc=
 github.com/relvacode/iso8601 v1.7.0 h1:BXy+V60stMP6cpswc+a93Mq3e65PfXCgDFfhvNNGrdo=
 github.com/relvacode/iso8601 v1.7.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rfjakob/eme v1.2.0 h1:8dAHL+WVAw06+7DkRKnRiFp1JL3QjcJEZFqDnndUaSI=

--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -20,7 +20,6 @@ import (
 	_ "rcbridge/envhack"
 
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -33,6 +32,7 @@ import (
 	goSync "sync"
 	"syscall"
 	"time"
+	_ "unsafe"
 
 	_ "golang.org/x/mobile/event/key"
 
@@ -42,7 +42,6 @@ import (
 	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/configstruct"
 	"github.com/rclone/rclone/fs/config/obscure"
-	"github.com/rclone/rclone/fs/fshttp"
 	"github.com/rclone/rclone/fs/fspath"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fs/sync"
@@ -62,8 +61,6 @@ var (
 	vfsInstances     = make(map[string]*vfs.VFS)
 	vfsOptValidKeys  = make(map[string]bool)
 	vfsOptStringKeys = make(map[string]bool)
-	caCertsLock      goSync.Mutex
-	caCertsPool      *x509.CertPool
 )
 
 func init() {
@@ -230,14 +227,6 @@ func generateTrustStorePool() *x509.CertPool {
 	return pool
 }
 
-// Set the trusted CA certificates on every HTTP request.
-func perRequestHook(config *tls.Config) {
-	caCertsLock.Lock()
-	defer caCertsLock.Unlock()
-
-	config.RootCAs = caCertsPool
-}
-
 // Initialize global aspects of the library.
 func RbInit() {
 	librclone.Initialize()
@@ -251,15 +240,21 @@ func RbInit() {
 	// agent is just "rclone/".
 	ci.UserAgent = fmt.Sprintf("rclone/%s", fs.VersionTag)
 
-	fshttp.SetRoundTripHook(perRequestHook)
+	RbReloadCerts()
 }
+
+//go:linkname systemRootsMu crypto/x509.systemRootsMu
+var systemRootsMu goSync.RWMutex
+
+//go:linkname systemRoots crypto/x509.systemRoots
+var systemRoots *x509.CertPool
 
 // Reload certificates from the system and user trust stores.
 func RbReloadCerts() {
-	caCertsLock.Lock()
-	defer caCertsLock.Unlock()
+	systemRootsMu.RLock()
+	defer systemRootsMu.RUnlock()
 
-	caCertsPool = generateTrustStorePool()
+	systemRoots = generateTrustStorePool()
 }
 
 // Clean up library resources.


### PR DESCRIPTION
Hooking per-request via rclone's `fshttp` happens too late and ends up overriding the user's `override.ca_cert` configuration if set. Instead, `systemRoots` in golang's `crypto/x509` now gets replaced directly. This eliminates the need to have a fork of rclone too.

Fixes: #287