### PR TITLE
Minor fixes to Compose UI

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/settings/AuthorizeDialog.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/AuthorizeDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
@@ -70,10 +71,12 @@ fun AuthorizeDialog(
             ),
         )
 
+        val latestOnReceive by rememberUpdatedState(onReceive)
+
         LaunchedEffect(Unit) {
             viewModel.code.collect {
                 if (it != null) {
-                    onReceive(it)
+                    latestOnReceive(it)
                 }
             }
         }

--- a/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteScreen.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/EditRemoteScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -175,16 +176,19 @@ fun EditRemoteScreen(
         )
     }
 
+    val latestOnEditNext by rememberUpdatedState(onEditNext)
+    val latestOnBack by rememberUpdatedState(onBack)
+
     LaunchedEffect(remote) {
         viewModel.activityActions.collect {
             if (it.refreshRoots) {
                 RcloneProvider.notifyRootsChanged(context)
             }
             it.editNewRemote?.let { newRemote ->
-                onEditNext(newRemote)
+                latestOnEditNext(newRemote)
             }
             if (it.finish) {
-                onBack()
+                latestOnBack()
             }
             viewModel.activityActionCompleted()
         }

--- a/app/src/main/java/com/chiller3/rsaf/settings/ErrorDetailsDialog.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/ErrorDetailsDialog.kt
@@ -9,6 +9,7 @@ package com.chiller3.rsaf.settings
 
 import android.content.ClipData
 import android.content.ClipboardManager
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
@@ -33,7 +34,9 @@ fun ErrorDetailsDialog(
         },
         text = {
             message?.let {
-                Text(text = it)
+                SelectionContainer {
+                    Text(text = it)
+                }
             }
         },
         onDismissRequest = onDismiss,

--- a/app/src/main/java/com/chiller3/rsaf/settings/InactivityTimeoutDialog.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/InactivityTimeoutDialog.kt
@@ -78,7 +78,6 @@ fun InactivityTimeoutDialog(
     )
 }
 
-@Composable
 private fun tryParseInput(input: String): Int? {
     try {
         val seconds = input.toInt()

--- a/app/src/main/java/com/chiller3/rsaf/settings/InteractiveConfigurationScreen.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/InteractiveConfigurationScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -71,6 +72,7 @@ import com.chiller3.rsaf.ui.PreferenceColumn
 import com.chiller3.rsaf.ui.PreferenceDefaults
 import com.chiller3.rsaf.ui.RadioPreference
 import com.chiller3.rsaf.ui.betterSegmentedShapes
+import com.chiller3.rsaf.ui.copy
 import com.chiller3.rsaf.ui.theme.AppTheme
 import com.chiller3.rsaf.ui.theme.Icons
 import org.json.JSONArray
@@ -101,7 +103,7 @@ fun InteractiveConfigurationScreen(
         title = { Text(text = title) },
         onBack = onCancel,
         backIsExit = true,
-        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.union(WindowInsets.ime)
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.union(WindowInsets.ime),
     ) { params ->
         question?.let { (error, option) ->
             InteractiveConfigurationContent(
@@ -124,12 +126,14 @@ fun InteractiveConfigurationScreen(
         onBack = { viewModel.goBack() },
     )
 
+    val latestOnComplete by rememberUpdatedState(onComplete)
+
     LaunchedEffect(Unit) {
         viewModel.run.collect {
             if (!it) {
                 // No more questions. We can just exit because changes are immediately
                 // committed upon submission.
-                onComplete()
+                latestOnComplete()
             }
         }
     }
@@ -228,9 +232,7 @@ private fun InteractiveConfigurationContent(
     var showAuthorizeDialog by rememberSaveable { mutableStateOf<String?>(null) }
 
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(contentPadding + PreferenceDefaults.ListPadding),
+        modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         val maxWidthModifier = Modifier
@@ -239,8 +241,7 @@ private fun InteractiveConfigurationContent(
 
         PreferenceColumn(
             modifier = Modifier.fillMaxSize().weight(weight = 1f),
-            contentPadding = PaddingValues(bottom = PreferenceDefaults.HorizontalPadding),
-            fillScreen = false,
+            contentPadding = contentPadding.copy(bottom = 0.dp),
         ) {
             item("message") {
                 val message = buildAnnotatedString {
@@ -316,18 +317,20 @@ private fun InteractiveConfigurationContent(
             }
         }
 
-        HorizontalDivider(modifier = maxWidthModifier)
+        Box(modifier = Modifier.padding(contentPadding + PreferenceDefaults.ListPadding)) {
+            HorizontalDivider(modifier = maxWidthModifier)
 
-        NavigationButtons(
-            hasPrevious = hasPrevious,
-            answer = answer,
-            onPrevQuestion = {
-                epoch++
-                onPrevQuestion()
-            },
-            onNextQuestion = onNextQuestion,
-            modifier = maxWidthModifier,
-        )
+            NavigationButtons(
+                hasPrevious = hasPrevious,
+                answer = answer,
+                onPrevQuestion = {
+                    epoch++
+                    onPrevQuestion()
+                },
+                onNextQuestion = onNextQuestion,
+                modifier = maxWidthModifier,
+            )
+        }
     }
 
     showAuthorizeDialog?.let { cmd ->
@@ -365,7 +368,7 @@ private fun AnswerTextField(
         OutlinedSecureTextField(
             state = state,
             modifier = modifier,
-            placeholder = { Text(text = option.name) },
+            label = { Text(text = option.name) },
             isError = answer == null,
             supportingText = { Text(text = supportingText) },
             trailingIcon = {
@@ -394,7 +397,7 @@ private fun AnswerTextField(
         OutlinedTextField(
             state = state,
             modifier = modifier,
-            placeholder = { Text(text = option.name) },
+            label = { Text(text = option.name) },
             isError = answer == null,
             supportingText = { Text(text = supportingText) },
             keyboardOptions = KeyboardOptions(

--- a/app/src/main/java/com/chiller3/rsaf/settings/PasswordDialog.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/PasswordDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedSecureTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldLabelScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,14 +51,14 @@ fun PasswordDialog(
                 TogglablePasswordField(
                     state = input,
                     modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                    placeholder = { Text(text = modeHint(mode)) },
+                    label = { Text(text = modeHint(mode)) },
                 )
 
                 if (mode == ImportExportMode.EXPORT) {
                     TogglablePasswordField(
                         state = inputConfirm,
                         modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                        placeholder = {
+                        label = {
                             Text(text = stringResource(R.string.dialog_export_password_confirm_hint))
                         },
                         isError = inputConfirm.text != input.text,
@@ -94,14 +95,14 @@ private fun TogglablePasswordField(
     state: TextFieldState,
     modifier: Modifier = Modifier,
     isError: Boolean = false,
-    placeholder: @Composable (() -> Unit)? = null,
+    label: @Composable (TextFieldLabelScope.() -> Unit)? = null,
 ) {
     var showPassword by rememberSaveable { mutableStateOf(false) }
 
     OutlinedSecureTextField(
         state = state,
         modifier = modifier,
-        placeholder = placeholder,
+        label = label,
         isError = isError,
         trailingIcon = {
             IconButton(onClick = { showPassword = !showPassword }) {

--- a/app/src/main/java/com/chiller3/rsaf/settings/RemoteNameDialog.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/RemoteNameDialog.kt
@@ -74,7 +74,7 @@ fun RemoteNameDialog(
                 OutlinedTextField(
                     state = input,
                     modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                    placeholder = { Text(text = stringResource(R.string.dialog_remote_name_hint)) },
+                    label = { Text(text = stringResource(R.string.dialog_remote_name_hint)) },
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.None,
                         autoCorrectEnabled = false,

--- a/app/src/main/java/com/chiller3/rsaf/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/SettingsScreen.kt
@@ -106,13 +106,13 @@ fun SettingsScreen(
     ) {
         reloadPerms++
     }
-    val requestPermissionRequired = rememberLauncherForActivityResult(
+    val requestPermissionsRequired = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions(),
     ) { granted ->
         if (granted.all { it.value }) {
             reloadPerms++
         } else {
-            context.startActivity(Permissions.getAppInfoIntent(context))
+            requestPermissionActivity.launch(Permissions.getAppInfoIntent(context))
         }
     }
     val requestSafImportConfiguration = rememberLauncherForActivityResult(
@@ -225,7 +225,7 @@ fun SettingsScreen(
                 requestPermissionActivity.launch(Permissions.getInhibitBatteryOptIntent(context))
             },
             onNotificationsGrant = {
-                requestPermissionRequired.launch(Permissions.NOTIFICATION)
+                requestPermissionsRequired.launch(Permissions.NOTIFICATION)
             },
             onRemoteAdd = { name ->
                 requestInteractiveConfiguration.launch(
@@ -260,7 +260,7 @@ fun SettingsScreen(
 
                     requestPermissionActivity.launch(intent)
                 } else if (enabled) {
-                    requestPermissionRequired.launch(Permissions.LEGACY_STORAGE)
+                    requestPermissionsRequired.launch(Permissions.LEGACY_STORAGE)
                 } else {
                     requestPermissionActivity.launch(Permissions.getAppInfoIntent(context))
                 }

--- a/app/src/main/java/com/chiller3/rsaf/ui/Screen.kt
+++ b/app/src/main/java/com/chiller3/rsaf/ui/Screen.kt
@@ -76,8 +76,8 @@ fun AppScreen(
         containerColor = PreferenceDefaults.containerColor,
         contentWindowInsets = contentWindowInsets,
     ) { contentPadding ->
-        val outerPadding = contentPadding.copy(bottom = 0.dp)
-        val innerPadding = contentPadding.copy(start = 0.dp, top = 0.dp, end = 0.dp)
+        val outerPadding = contentPadding.copy(start = 0.dp, end = 0.dp, bottom = 0.dp)
+        val innerPadding = contentPadding.copy(top = 0.dp)
 
         Box(modifier = Modifier.padding(outerPadding)) {
             content(AppScreenParams(


### PR DESCRIPTION
- Adjust window insets to allow scrolling from inset region
- Make error dialog text selectable
- Use `TextFieldState` for all `TextField`s
- Make `TextField`s single line where appropriate
- Remove viewbinding generation now that we don't use views
- Use `rememberUpdatedState` where appropriate
- Remove `@Composable` for functions that don't need it
- Fix reloading permission state after denying once and then granting via Android's settings