### PR TITLE
rcbridge: Ensure crypto/x509.once runs once when reloading certs

### DIFF
--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -221,9 +221,9 @@ func generateTrustStorePool() *x509.CertPool {
 		for _, cert := range certs {
 			pool.AddCert(cert)
 		}
-	}
 
-	fs.Logf(nil, "Loaded %d certificates", len(caFiles))
+		fs.Logf(nil, "Loaded %d certificate(s) from: %v", len(certs), path)
+	}
 
 	return pool
 }
@@ -244,6 +244,9 @@ func RbInit() {
 	RbReloadCerts()
 }
 
+//go:linkname once crypto/x509.once
+var once goSync.Once
+
 //go:linkname systemRootsMu crypto/x509.systemRootsMu
 var systemRootsMu goSync.RWMutex
 
@@ -252,6 +255,10 @@ var systemRoots *x509.CertPool
 
 // Reload certificates from the system and user trust stores.
 func RbReloadCerts() {
+	once.Do(func() {
+		fs.Logf(nil, "Skipped golang's initial CA trust store load")
+	})
+
 	systemRootsMu.RLock()
 	defer systemRootsMu.RUnlock()
 


### PR DESCRIPTION
Previously, nothing triggered `crypto/x509.once`, so the first time that an HTTPS connection was made, golang would load CA certs itself and overwrite was rcbridge already loaded.

852a841228a9a3f8962a6e33a46812bddf4eaac2 introduced this regression. This wasn't caught because the test process always started from a fresh state and the CA cert was added to the user trust store while RSAF was already running and attempted an HTTPS connection once.

Fixes: #302