### PR TITLE
Make back navigation icon filled

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/ui/Screen.kt
+++ b/app/src/main/java/com/chiller3/rsaf/ui/Screen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarHost
@@ -51,7 +53,12 @@ fun AppScreen(
                 title = title,
                 navigationIcon = {
                     onBack?.let { onClick ->
-                        IconButton(onClick = onClick) {
+                        IconButton(
+                            onClick = onClick,
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                            ),
+                        ) {
                             if (backIsExit) {
                                 Icon(
                                     imageVector = Icons.Close,


### PR DESCRIPTION
Matches Android SettingsLib's `settingslib_expressive_icon_back.xml` for Material 3 Expressive styling.