### PR TITLE
InteractiveConfigurationScreen: Use example index as key

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/settings/InteractiveConfigurationScreen.kt
+++ b/app/src/main/java/com/chiller3/rsaf/settings/InteractiveConfigurationScreen.kt
@@ -304,10 +304,9 @@ private fun InteractiveConfigurationContent(
                     }
                 }
 
-                itemsIndexed(
-                    option.examples,
-                    key = { _, e -> "example_${e.value}" },
-                ) { index, example ->
+                // We intentionally rely on the default behavior of using the item index as the key.
+                // rclone does not guarantee any of the fields within an example to be unique.
+                itemsIndexed(option.examples) { index, example ->
                     val isSelected = answer == example.value
                     val onClick = { input.edit { replace(0, length, example.value) } }
 


### PR DESCRIPTION
rclone doesn't guarantee that examples have unique values. For the onedrive backend specifically, the `config_driveid` question always has two identical options with the same value, but different descriptions. Previously, this would result in a crash because Compose requires unique keys.

Issue: #311