### PR TITLE
ui: Adjust background color to match AOSP SettingsLib

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/ui/Preferences.kt
+++ b/app/src/main/java/com/chiller3/rsaf/ui/Preferences.kt
@@ -65,9 +65,9 @@ object PreferenceDefaults {
     val ListPadding = PaddingValues(horizontal = HorizontalPadding)
 
     val containerColor: Color
-        @Composable get() = MaterialTheme.colorScheme.surfaceContainerHigh
+        @Composable get() = MaterialTheme.colorScheme.surfaceContainer
     val scrolledContainerColor: Color
-        @Composable get() = MaterialTheme.colorScheme.surfaceContainerLow
+        @Composable get() = MaterialTheme.colorScheme.surfaceContainerHighest
 
     @Composable
     fun appBarColors() = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/com/chiller3/rsaf/ui/Screen.kt
+++ b/app/src/main/java/com/chiller3/rsaf/ui/Screen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarHost
@@ -56,7 +55,7 @@ fun AppScreen(
                         IconButton(
                             onClick = onClick,
                             colors = IconButtonDefaults.filledIconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                containerColor = PreferenceDefaults.scrolledContainerColor,
                             ),
                         ) {
                             if (backIsExit) {

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,7 +10,7 @@
             the same app.
             This must be set statically. Keep this in sync with PreferenceDefaults.containerColor.
         -->
-        <item name="android:colorBackground">?attr/colorSurfaceContainerHigh</item>
+        <item name="android:colorBackground">?attr/colorSurfaceContainer</item>
 
         <!--
             This prevents an ugly bar from showing up in the recents screen when another app is


### PR DESCRIPTION
The previous color was set to Compose's default background color for dialogs, which looked nice, but didn't match AOSP Settings. However, it resulted in relatively low contrast with the filled back button icon background due to the colors being only one step apart instead of two.