### PR TITLE
Authorizer: Cancel if server exits unexpectedly

### DIFF
--- a/app/src/main/java/com/chiller3/rsaf/rclone/AuthorizeService.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/AuthorizeService.kt
@@ -97,6 +97,11 @@ class AuthorizeService : Service(), Authorizer.AuthorizeListener {
                     authorizeThread = Thread {
                         try {
                             Authorizer.authorizeBlocking(cmd, this)
+
+                            // Give the client some sort of response so that it knows we exited.
+                            if (authorizeCode == null) {
+                                onAuthorizeCode("")
+                            }
                         } catch (e: Exception) {
                             Log.e(TAG, "Failed to run authorizer", e)
                         } finally {
@@ -124,8 +129,7 @@ class AuthorizeService : Service(), Authorizer.AuthorizeListener {
 
     private fun cancel() {
         if (!cancelled) {
-            // This cannot be done on the main thread because it makes a localhost HTTP request.
-            Thread(Authorizer::cancel).start()
+            Authorizer.cancel()
             cancelled = true
         }
     }

--- a/app/src/main/java/com/chiller3/rsaf/rclone/Authorizer.kt
+++ b/app/src/main/java/com/chiller3/rsaf/rclone/Authorizer.kt
@@ -79,6 +79,7 @@ object Authorizer {
                 }
 
                 Log.d(TAG, "Stopped authorize server")
+                cancelLogReader()
             }.apply { start() }
 
             try {


### PR DESCRIPTION
Previously, the authorization dialog remained open indefinitely with a broken URL if the server exited unexpectedly. Now, it will behave as if it received an empty code.