### PR TITLE
rcbridge: Disable HTTP/2

### DIFF
--- a/rcbridge/rcbridge.go
+++ b/rcbridge/rcbridge.go
@@ -241,6 +241,10 @@ func RbInit() {
 	// agent is just "rclone/".
 	ci.UserAgent = fmt.Sprintf("rclone/%s", fs.VersionTag)
 
+	// Disable HTTP/2 to avoid low throughput due to golang's HTTP client.
+	// https://github.com/rclone/rclone/issues/8379
+	ci.DisableHTTP2 = true
+
 	RbReloadCerts()
 }
 


### PR DESCRIPTION
Equivalent to rclone's `--disable-http2` global option. There are unfixed issues with golang's HTTP client that result in low throughput. For now, HTTP/2 will just be disabled without any configuration option to reenable it since it does not provide much benefit for RSAF's use case anyway.

Upstream: https://github.com/rclone/rclone/issues/8379
Fixes: #326